### PR TITLE
feat: add api_base_url for dual-URL routing (auth vs data)

### DIFF
--- a/eko_client/client.py
+++ b/eko_client/client.py
@@ -23,9 +23,14 @@ logger = logging.getLogger(__name__)
 class BaseEkoClient:
     """Base client with common functionality for async and sync operations."""
     
+    # Auth endpoint prefixes — requests matching these use base_url (auth service).
+    # Everything else uses api_base_url (data service) when provided.
+    _AUTH_PREFIXES = ("/api/auth/",)
+
     def __init__(
         self,
         base_url: str,
+        api_base_url: Optional[str] = None,
         token: Optional[str] = None,
         username: Optional[str] = None,
         password: Optional[str] = None,
@@ -34,9 +39,14 @@ class BaseEkoClient:
     ):
         """
         Initialize base client.
-        
+
         Args:
-            base_url: API base URL (e.g., 'http://localhost:8000')
+            base_url: API base URL for auth endpoints (e.g., 'https://auth-dev.jana.earth').
+                When api_base_url is not set, this is used for all requests.
+            api_base_url: Optional separate base URL for data/ESG endpoints
+                (e.g., 'https://api-dev.jana.earth'). When set, auth endpoints
+                (``/api/auth/...``) continue to use base_url while all other
+                requests are sent to api_base_url.
             token: Authentication token (if available)
             username: Username for login (if token not provided)
             password: Password for login (if token not provided)
@@ -44,6 +54,7 @@ class BaseEkoClient:
             verify_ssl: Whether to verify SSL certificates
         """
         self.base_url = base_url.rstrip('/')
+        self.api_base_url = api_base_url.rstrip('/') if api_base_url else None
         self.token = token
         self.username = username
         self.password = password
@@ -80,6 +91,19 @@ class BaseEkoClient:
             )
         return self._sync_client
     
+    def _resolve_base_url(self, endpoint: str) -> str:
+        """Return the correct base URL for the given endpoint.
+
+        Auth endpoints (``/api/auth/...``) always use ``self.base_url``.
+        All other endpoints use ``self.api_base_url`` when it is set,
+        falling back to ``self.base_url`` otherwise.
+        """
+        if self.api_base_url and not any(
+            endpoint.startswith(prefix) for prefix in self._AUTH_PREFIXES
+        ):
+            return self.api_base_url
+        return self.base_url
+
     def _get_headers(self) -> Dict[str, str]:
         """Get default headers including authentication."""
         headers = {
@@ -119,13 +143,13 @@ class BaseEkoClient:
             EkoRateLimitError: If rate limit is exceeded
             EkoNotFoundError: If resource not found
         """
-        url = build_url(self.base_url, endpoint)
+        url = build_url(self._resolve_base_url(endpoint), endpoint)
         headers = self._get_headers()
-        
+
         # Format query parameters
         if params:
             params = format_query_params(params)
-        
+
         async with self._async_lock:
             client = self._get_async_client()
             
@@ -171,13 +195,13 @@ class BaseEkoClient:
             EkoRateLimitError: If rate limit is exceeded
             EkoNotFoundError: If resource not found
         """
-        url = build_url(self.base_url, endpoint)
+        url = build_url(self._resolve_base_url(endpoint), endpoint)
         headers = self._get_headers()
-        
+
         # Format query parameters
         if params:
             params = format_query_params(params)
-        
+
         with self._sync_lock:
             client = self._get_sync_client()
             

--- a/eko_client/user_client.py
+++ b/eko_client/user_client.py
@@ -40,12 +40,18 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
     - Async methods end with '_async' suffix (e.g., get_data_async)
     - Sync methods are auto-generated without the suffix (e.g., get_data)
 
-    Example:
+    Example (single URL — all requests go to one host):
         >>> client = EkoUserClient(base_url="https://api.jana.com")
         >>> client.login_device()  # opens browser for OAuth 2.0 device code flow
-        >>> # or: client.login_password("user@example.com", "secret")
-        >>> data = client.get_data(sources=["openaq", "climatetrace"])  # Sync version (auto-generated)
-        >>> data = await client.get_data_async(sources=["openaq", "climatetrace"])  # Async version
+        >>> data = client.get_data(sources=["openaq", "climatetrace"])
+
+    Example (dual URL — auth and data on separate hosts):
+        >>> client = EkoUserClient(
+        ...     base_url="https://auth-dev.jana.earth",      # auth endpoints
+        ...     api_base_url="https://api-dev.jana.earth",    # data/ESG endpoints
+        ... )
+        >>> client.login_device()       # -> auth-dev.jana.earth/api/auth/device-code/
+        >>> data = client.get_data(...)  # -> api-dev.jana.earth/api/v1/esg/data/
     """
 
     # =============================================================================


### PR DESCRIPTION
## Summary
- Adds `api_base_url` parameter to `BaseEkoClient` so auth endpoints (`/api/auth/*`) go to one host (e.g. `auth-dev.jana.earth`) and data/ESG endpoints go to another (e.g. `api-dev.jana.earth`)
- Adds `_resolve_base_url(endpoint)` method that checks endpoint prefix to pick the right base URL
- Fully backward compatible — omitting `api_base_url` preserves single-URL behaviour

## Problem
When the client is pointed at `auth-dev.jana.earth` for JWT device-code auth, ESG data calls (e.g. `/api/v1/esg/correlations/`) also go there and get 502 because that ALB only routes `/api/auth/*` to jana-user and everything else to jana-api-internal which fails.

## Test plan
- [ ] Verify `EkoUserClient(base_url="https://auth-dev.jana.earth", api_base_url="https://api-dev.jana.earth")` routes auth to auth-dev and data to api-dev
- [ ] Verify `EkoUserClient(base_url="https://api.jana.earth")` (no api_base_url) still works as before
- [ ] Run device-code test suite with dual URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)