### PR TITLE
fix: unwrap data in get_user_info for API response compatibility

### DIFF
--- a/eko_client/jwt_auth.py
+++ b/eko_client/jwt_auth.py
@@ -400,12 +400,19 @@ class JwtAuthMixin:
     # ------------------------------------------------------------------
 
     def get_user_info(self) -> dict:
-        """Return the authenticated user's profile from ``/api/auth/user/``."""
-        return self._request_sync("GET", "/api/auth/user/")
+        """Return the authenticated user's profile from ``/api/auth/user/``.
+
+        Unwraps ``data`` if the API returns ``{"data": {"username": ..., "email": ...}}``,
+        so callers can use ``user_info.get("username")`` / ``user_info.get("email")``
+        regardless of response shape.
+        """
+        response = self._request_sync("GET", "/api/auth/user/")
+        return response.get("data") or response
 
     async def get_user_info_async(self) -> dict:
         """Async version of :meth:`get_user_info`."""
-        return await self._request_async("GET", "/api/auth/user/")
+        response = await self._request_async("GET", "/api/auth/user/")
+        return response.get("data") or response
 
     # ------------------------------------------------------------------
     # Helpers


### PR DESCRIPTION
When `/api/auth/user/` returns `{"data": {"username": ..., "email": ...}}`, unwrap so callers get username/email directly.

Fixes 'Logged in as: unknown' / 'Email: N/A' after device code flow when the API wraps the user object in a `data` key.

Made with [Cursor](https://cursor.com)