### PR TITLE
fix: correct OpenAQ param names, add missing filter/pagination params, increase timeout

### DIFF
--- a/eko_client/client.py
+++ b/eko_client/client.py
@@ -35,7 +35,7 @@ class BaseEkoClient:
         token: Optional[str] = None,
         username: Optional[str] = None,
         password: Optional[str] = None,
-        timeout: int = 30,
+        timeout: int = 120,
         verify_ssl: bool = True,
     ):
         """
@@ -51,7 +51,7 @@ class BaseEkoClient:
             token: Authentication token (if available)
             username: Username for login (if token not provided)
             password: Password for login (if token not provided)
-            timeout: Request timeout in seconds
+            timeout: Request timeout in seconds (default 120 for large aggregation queries)
             verify_ssl: Whether to verify SSL certificates
         """
         self.base_url = base_url.rstrip('/')

--- a/eko_client/user_client.py
+++ b/eko_client/user_client.py
@@ -616,16 +616,31 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
     # OpenAQ Methods
     async def get_openaq_locations_async(
         self,
-        country_codes: Optional[List[str]] = None,
+        country_codes: Optional[Union[List[str], str]] = None,
         location_bbox: Optional[List[float]] = None,
+        page: Optional[int] = None,
+        page_size: Optional[int] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
     ) -> Dict[str, Any]:
-        """Get OpenAQ locations."""
+        """Get OpenAQ locations.
+
+        Args:
+            country_codes: Country code(s) — single string or list (e.g. 'US' or ['US', 'GB']).
+            location_bbox: Geographic bounding box [min_lon, min_lat, max_lon, max_lat].
+            page: Page number (1-based).
+            page_size: Number of results per page.
+            limit: Alias for page_size (backward compatibility).
+            offset: Result offset (backward compatibility).
+        """
+        # Normalize single string to list for consistent handling
+        if isinstance(country_codes, str):
+            country_codes = [country_codes]
         params = {
             'country_codes': country_codes,
             'location_bbox': location_bbox,
-            'limit': limit,
+            'page': page,
+            'page_size': page_size or limit,
             'offset': offset,
         }
         return await self._request_async('GET', '/api/v1/data-sources/openaq/locations/', params=params)
@@ -645,7 +660,7 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
         """Get OpenAQ sensors."""
         params = {
             'location_id': location_id,
-            'parameter': parameter,
+            'parameter__name': parameter,
             'limit': limit,
             'offset': offset,
         }
@@ -662,16 +677,36 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
         parameter: Optional[str] = None,
         date_from: Optional[Union[str, datetime]] = None,
         date_to: Optional[Union[str, datetime]] = None,
+        country_code: Optional[str] = None,
+        ordering: Optional[str] = None,
+        page: Optional[int] = None,
+        page_size: Optional[int] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
     ) -> Dict[str, Any]:
-        """Get OpenAQ measurements."""
+        """Get OpenAQ measurements.
+
+        Args:
+            location_id: Filter by location ID.
+            parameter: Filter by parameter name (e.g. 'pm25', 'o3').
+            date_from: Start date (ISO 8601 string or datetime).
+            date_to: End date (ISO 8601 string or datetime).
+            country_code: Filter by country code (e.g. 'US').
+            ordering: Sort field (e.g. 'measured_at', '-measured_at').
+            page: Page number (1-based, used with page_size).
+            page_size: Number of results per page.
+            limit: Alias for page_size (backward compatibility).
+            offset: Result offset (backward compatibility).
+        """
         params = {
             'location_id': location_id,
-            'parameter': parameter,
+            'parameter_name': parameter,
             'date_from': date_from.isoformat() if isinstance(date_from, datetime) else date_from,
             'date_to': date_to.isoformat() if isinstance(date_to, datetime) else date_to,
-            'limit': limit,
+            'location__country_code': country_code,
+            'ordering': ordering,
+            'page': page,
+            'page_size': page_size or limit,
             'offset': offset,
         }
         return await self._request_async('GET', '/api/v1/data-sources/openaq/measurements/', params=params)


### PR DESCRIPTION
## Summary
- **OpenAQ measurements**: `parameter` → `parameter_name` — server expects `parameter_name` via DjangoFilterBackend; the mismatch meant parameter filters were silently ignored and the hidden 7-day default filter activated
- **OpenAQ sensors**: `parameter` → `parameter__name` — correct Django ORM relation name for filterset_fields
- **OpenAQ measurements**: added `country_code`, `ordering`, `page`, `page_size` params to eliminate `_request_sync` workarounds in notebooks
- **OpenAQ locations**: added `page`, `page_size` params; `country_codes` now accepts a single string or list
- **Client timeout**: 30s → 120s — 10-country aggregation queries take ~46s, causing false timeout errors

## Test plan
- [x] Verified `get_openaq_measurements(country_code='US', date_from=...)` returns 21.7M records (no 7-day filter)
- [x] Verified `get_openaq_measurements(parameter='pm25')` correctly maps to `parameter_name` (72.9M records)
- [x] Verified `get_openaq_locations(country_codes='US', page_size=5)` returns 5,540 locations
- [x] Verified `get_aggregations(country_codes=[10 countries])` succeeds with 120s timeout (was failing at 30s)
- [x] Confirmed no `_request_sync` workarounds remain in data-analyst notebooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)