### PR TITLE
test: comprehensive unit test suite + README dev docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md — jana-eko-client project conventions
+
+> **Maintenance note:** Shared rules (git workflow, shell scripting, AWS auth, deploy policy, etc.) live in the parent `repos/CLAUDE.md` and are inherited automatically. This file contains only project-specific instructions. When updating, ask: "Does this apply to every repo, or just this project?" Shared rules go in `repos/CLAUDE.md`; project-specific rules go here.

--- a/README.md
+++ b/README.md
@@ -367,6 +367,68 @@ with EkoUserClient(base_url="...", token="...") as client:
 # Client is automatically closed
 ```
 
+## Development
+
+### Setup
+
+```bash
+git clone https://github.com/Jana-Earth-Data/jana-eko-client
+cd jana-eko-client
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+### Running Tests
+
+```bash
+# Run all tests
+pytest
+
+# Run with verbose output
+pytest -v
+
+# Run with coverage report
+pytest --cov=eko_client --cov-report=term-missing
+
+# Run a specific test file
+pytest tests/test_jwt_auth.py
+
+# Run a specific test class or method
+pytest tests/test_pagination.py::TestFetchAllPagesSync::test_multi_page_with_count
+```
+
+### Test Suite
+
+The test suite uses [respx](https://github.com/lundberg/respx) for HTTP mocking (no live API required) and [pytest-asyncio](https://github.com/pytest-dev/pytest-asyncio) for async test support.
+
+**300 tests, 99.8% coverage** across all modules:
+
+| Module | Coverage |
+|--------|----------|
+| `client.py` (BaseEkoClient) | 99% |
+| `user_client.py` (EkoUserClient) | 100% |
+| `admin_client.py` (EkoAdminClient) | 100% |
+| `jwt_auth.py` (JwtAuthMixin) | 100% |
+| `auth.py` (AuthMixin) | 100% |
+| `sync_wrapper.py` | 100% |
+| `exceptions.py` | 100% |
+| `models.py` | 100% |
+| `utils.py` | 100% |
+
+### Code Style
+
+```bash
+# Format with black
+black eko_client/ tests/
+
+# Lint with ruff
+ruff check eko_client/ tests/
+
+# Type check with mypy
+mypy eko_client/
+```
+
 ## Requirements
 
 - Python 3.8+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dependencies = [
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
+    "pytest-cov>=4.0.0",
+    "respx>=0.20.0",
     "black>=23.0.0",
     "mypy>=1.0.0",
     "ruff>=0.1.0",
@@ -61,6 +63,18 @@ python_version = "3.8"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[tool.coverage.run]
+source = ["eko_client"]
+omit = ["tests/*"]
+
+[tool.coverage.report]
+show_missing = true
+fail_under = 85
 
 [tool.ruff]
 line-length = 100

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,69 @@
+"""Shared fixtures for jana-eko-client tests."""
+
+import pytest
+import httpx
+import respx
+from unittest.mock import patch
+
+from eko_client.client import BaseEkoClient
+from eko_client.user_client import EkoUserClient
+from eko_client.admin_client import EkoAdminClient
+
+
+BASE_URL = "https://test.jana.earth"
+API_BASE_URL = "https://api-test.jana.earth"
+
+
+@pytest.fixture
+def base_client():
+    """BaseEkoClient with a pre-set token (skip auto-login)."""
+    client = BaseEkoClient(base_url=BASE_URL, token="test-token-abc123")
+    yield client
+    client.close()
+
+
+@pytest.fixture
+def base_client_dual():
+    """BaseEkoClient with separate auth and API base URLs."""
+    client = BaseEkoClient(
+        base_url=BASE_URL,
+        api_base_url=API_BASE_URL,
+        token="test-token-abc123",
+    )
+    yield client
+    client.close()
+
+
+@pytest.fixture
+def user_client():
+    """EkoUserClient with a pre-set DRF token (skip auto-login)."""
+    client = EkoUserClient(base_url=BASE_URL, token="test-token-abc123")
+    yield client
+    client.close()
+
+
+@pytest.fixture
+def user_client_dual():
+    """EkoUserClient with separate auth and API base URLs."""
+    client = EkoUserClient(
+        base_url=BASE_URL,
+        api_base_url=API_BASE_URL,
+        token="test-token-abc123",
+    )
+    yield client
+    client.close()
+
+
+@pytest.fixture
+def admin_client():
+    """EkoAdminClient with a pre-set DRF token (skip auto-login)."""
+    client = EkoAdminClient(base_url=BASE_URL, token="test-token-abc123")
+    yield client
+    client.close()
+
+
+@pytest.fixture
+def mock_api():
+    """respx mock router scoped to each test."""
+    with respx.mock(assert_all_called=False) as rsps:
+        yield rsps

--- a/tests/test_admin_client.py
+++ b/tests/test_admin_client.py
@@ -1,0 +1,354 @@
+"""Tests for eko_client.admin_client — EkoAdminClient endpoint methods."""
+
+import pytest
+import httpx
+import respx
+from datetime import datetime
+
+from eko_client.admin_client import EkoAdminClient
+from eko_client.user_client import EkoUserClient
+
+BASE_URL = "https://test.jana.earth"
+OK = {"results": [{"id": 1}], "count": 1}
+
+
+def _client():
+    return EkoAdminClient(base_url=BASE_URL, token="tok")
+
+
+class TestAdminInheritance:
+
+    def test_inherits_user_client(self):
+        assert issubclass(EkoAdminClient, EkoUserClient)
+
+    @respx.mock
+    def test_can_call_user_methods(self):
+        """Admin client inherits all EkoUserClient methods."""
+        respx.get(f"{BASE_URL}/api/v1/esg/health/").mock(
+            return_value=httpx.Response(200, json={"status": "ok"})
+        )
+        client = _client()
+        result = client.get_health()
+        assert result["status"] == "ok"
+        client.close()
+
+
+# ── Job Management ───────────────────────────────────────────────────────────
+
+class TestJobManagement:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_list_jobs(self):
+        respx.get(f"{BASE_URL}/api/v1/management/jobs/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.list_jobs_async(
+            data_source="openaq", job_type="ingest", status="active",
+            is_active=True, limit=10,
+        )
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    def test_list_jobs_sync(self):
+        respx.get(f"{BASE_URL}/api/v1/management/jobs/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = client.list_jobs(limit=10)
+        assert result == OK
+        client.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_job(self):
+        respx.get(f"{BASE_URL}/api/v1/management/jobs/5/").mock(
+            return_value=httpx.Response(200, json={"id": 5})
+        )
+        client = _client()
+        result = await client.get_job_async(5)
+        assert result["id"] == 5
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_create_job(self):
+        respx.post(f"{BASE_URL}/api/v1/management/jobs/").mock(
+            return_value=httpx.Response(201, json={"id": 10})
+        )
+        client = _client()
+        result = await client.create_job_async({"name": "test", "type": "ingest"})
+        assert result["id"] == 10
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_update_job(self):
+        respx.put(f"{BASE_URL}/api/v1/management/jobs/5/").mock(
+            return_value=httpx.Response(200, json={"id": 5, "name": "updated"})
+        )
+        client = _client()
+        result = await client.update_job_async(5, {"name": "updated"})
+        assert result["name"] == "updated"
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_delete_job(self):
+        respx.delete(f"{BASE_URL}/api/v1/management/jobs/5/").mock(
+            return_value=httpx.Response(204, json={})
+        )
+        client = _client()
+        await client.delete_job_async(5)
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_trigger_job(self):
+        respx.post(f"{BASE_URL}/api/v1/management/jobs/5/trigger/").mock(
+            return_value=httpx.Response(200, json={"execution_id": "abc"})
+        )
+        client = _client()
+        result = await client.trigger_job_async(5, override_config={"key": "val"})
+        assert result["execution_id"] == "abc"
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_trigger_job_no_config(self):
+        respx.post(f"{BASE_URL}/api/v1/management/jobs/5/trigger/").mock(
+            return_value=httpx.Response(200, json={"execution_id": "def"})
+        )
+        client = _client()
+        result = await client.trigger_job_async(5)
+        assert result["execution_id"] == "def"
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_pause_job(self):
+        respx.post(f"{BASE_URL}/api/v1/management/jobs/5/pause/").mock(
+            return_value=httpx.Response(200, json={"status": "paused"})
+        )
+        client = _client()
+        result = await client.pause_job_async(5)
+        assert result["status"] == "paused"
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_resume_job(self):
+        respx.post(f"{BASE_URL}/api/v1/management/jobs/5/resume/").mock(
+            return_value=httpx.Response(200, json={"status": "active"})
+        )
+        client = _client()
+        result = await client.resume_job_async(5)
+        assert result["status"] == "active"
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_job_executions(self):
+        respx.get(f"{BASE_URL}/api/v1/management/jobs/5/executions/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_job_executions_async(5, status="completed", limit=10)
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_job_stats(self):
+        respx.get(f"{BASE_URL}/api/v1/management/jobs/5/stats/").mock(
+            return_value=httpx.Response(200, json={"total_runs": 42})
+        )
+        client = _client()
+        result = await client.get_job_stats_async(5)
+        assert result["total_runs"] == 42
+        await client.close_async()
+
+
+# ── Execution Management ─────────────────────────────────────────────────────
+
+class TestExecutionManagement:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_list_executions(self):
+        respx.get(f"{BASE_URL}/api/v1/management/executions/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.list_executions_async(
+            job=5, status="completed",
+            date_from=datetime(2024, 1, 1),
+            date_to="2024-12-31",
+        )
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_execution(self):
+        respx.get(f"{BASE_URL}/api/v1/management/executions/10/").mock(
+            return_value=httpx.Response(200, json={"id": 10})
+        )
+        client = _client()
+        result = await client.get_execution_async(10)
+        assert result["id"] == 10
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_execution_logs(self):
+        respx.get(f"{BASE_URL}/api/v1/management/executions/10/logs/").mock(
+            return_value=httpx.Response(200, json={"logs": ["line1"]})
+        )
+        client = _client()
+        result = await client.get_execution_logs_async(10)
+        assert "logs" in result
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_cancel_execution(self):
+        respx.post(f"{BASE_URL}/api/v1/management/executions/10/cancel/").mock(
+            return_value=httpx.Response(200, json={"status": "cancelled"})
+        )
+        client = _client()
+        result = await client.cancel_execution_async(10)
+        assert result["status"] == "cancelled"
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_retry_execution(self):
+        respx.post(f"{BASE_URL}/api/v1/management/executions/10/retry/").mock(
+            return_value=httpx.Response(200, json={"id": 11})
+        )
+        client = _client()
+        result = await client.retry_execution_async(10)
+        assert result["id"] == 11
+        await client.close_async()
+
+
+# ── Data Source Management ───────────────────────────────────────────────────
+
+class TestDataSourceManagement:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_list_data_sources(self):
+        respx.get(f"{BASE_URL}/api/v1/management/data-sources/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.list_data_sources_async(is_active=True, limit=10)
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_data_source(self):
+        respx.get(f"{BASE_URL}/api/v1/management/data-sources/3/").mock(
+            return_value=httpx.Response(200, json={"id": 3})
+        )
+        client = _client()
+        result = await client.get_data_source_async(3)
+        assert result["id"] == 3
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_create_data_source(self):
+        respx.post(f"{BASE_URL}/api/v1/management/data-sources/").mock(
+            return_value=httpx.Response(201, json={"id": 4})
+        )
+        client = _client()
+        result = await client.create_data_source_async({"name": "new-source"})
+        assert result["id"] == 4
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_update_data_source(self):
+        respx.put(f"{BASE_URL}/api/v1/management/data-sources/3/").mock(
+            return_value=httpx.Response(200, json={"id": 3, "name": "updated"})
+        )
+        client = _client()
+        result = await client.update_data_source_async(3, {"name": "updated"})
+        assert result["name"] == "updated"
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_delete_data_source(self):
+        respx.delete(f"{BASE_URL}/api/v1/management/data-sources/3/").mock(
+            return_value=httpx.Response(204, json={})
+        )
+        client = _client()
+        await client.delete_data_source_async(3)
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_check_data_source_health(self):
+        respx.post(f"{BASE_URL}/api/v1/management/data-sources/3/check_health/").mock(
+            return_value=httpx.Response(200, json={"healthy": True})
+        )
+        client = _client()
+        result = await client.check_data_source_health_async(3)
+        assert result["healthy"] is True
+        await client.close_async()
+
+
+# ── System Management ────────────────────────────────────────────────────────
+
+class TestSystemManagement:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_management_health(self):
+        respx.get(f"{BASE_URL}/api/v1/management/health/").mock(
+            return_value=httpx.Response(200, json={"status": "ok"})
+        )
+        client = _client()
+        result = await client.get_management_health_async()
+        assert result["status"] == "ok"
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_management_summary(self):
+        respx.get(f"{BASE_URL}/api/v1/management/summary/").mock(
+            return_value=httpx.Response(200, json={"overview": {}})
+        )
+        client = _client()
+        result = await client.get_management_summary_async()
+        assert "overview" in result
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_database_performance(self):
+        respx.get(f"{BASE_URL}/api/v1/management/database/performance/").mock(
+            return_value=httpx.Response(200, json={"connections": 10})
+        )
+        client = _client()
+        result = await client.get_database_performance_async()
+        assert result["connections"] == 10
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_redis_performance(self):
+        respx.get(f"{BASE_URL}/api/v1/management/redis/performance/").mock(
+            return_value=httpx.Response(200, json={"used_memory": "50MB"})
+        )
+        client = _client()
+        result = await client.get_redis_performance_async()
+        assert "used_memory" in result
+        await client.close_async()

--- a/tests/test_auth_mixin.py
+++ b/tests/test_auth_mixin.py
@@ -1,0 +1,70 @@
+"""Tests for eko_client.auth — AuthMixin (legacy, superseded by JwtAuthMixin)."""
+
+import pytest
+import httpx
+import respx
+
+from eko_client.auth import AuthMixin
+from eko_client.client import BaseEkoClient
+
+BASE_URL = "https://test.jana.earth"
+
+
+class TestAuthMixin:
+    """AuthMixin delegates to BaseEkoClient.login/logout. Verify the MRO works."""
+
+    @respx.mock
+    def test_login_delegates(self):
+        respx.post(f"{BASE_URL}/api/auth/login/").mock(
+            return_value=httpx.Response(200, json={"token": "tok-from-mixin"})
+        )
+
+        class TestClient(AuthMixin, BaseEkoClient):
+            pass
+
+        client = TestClient(base_url=BASE_URL)
+        token = client.login("u", "p")
+        assert token == "tok-from-mixin"
+        client.close()
+
+    @respx.mock
+    def test_logout_clears_token(self):
+        respx.post(f"{BASE_URL}/api/auth/logout/").mock(
+            return_value=httpx.Response(200, json={"status": "ok"})
+        )
+
+        class TestClient(AuthMixin, BaseEkoClient):
+            pass
+
+        client = TestClient(base_url=BASE_URL, token="tok")
+        client.logout()
+        assert client.token is None
+
+    @respx.mock
+    def test_get_user_info(self):
+        respx.get(f"{BASE_URL}/api/auth/user/").mock(
+            return_value=httpx.Response(200, json={"username": "dev-user"})
+        )
+
+        class TestClient(AuthMixin, BaseEkoClient):
+            pass
+
+        client = TestClient(base_url=BASE_URL, token="tok")
+        info = client.get_user_info()
+        assert info["username"] == "dev-user"
+        client.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_user_info_async(self):
+        respx.get(f"{BASE_URL}/api/auth/user/").mock(
+            return_value=httpx.Response(200, json={"username": "dev-user"})
+        )
+
+        class TestClient(AuthMixin, BaseEkoClient):
+            pass
+
+        client = TestClient(base_url=BASE_URL, token="tok")
+        info = await client.get_user_info_async()
+        assert info["username"] == "dev-user"
+        await client.close_async()

--- a/tests/test_base_client.py
+++ b/tests/test_base_client.py
@@ -1,0 +1,393 @@
+"""Tests for eko_client.client — BaseEkoClient core functionality."""
+
+import json
+import pytest
+import httpx
+import respx
+
+from eko_client.client import BaseEkoClient
+from eko_client.exceptions import (
+    EkoClientError,
+    EkoAuthenticationError,
+    EkoAPIError,
+    EkoRateLimitError,
+    EkoNotFoundError,
+)
+
+BASE_URL = "https://test.jana.earth"
+API_BASE_URL = "https://api-test.jana.earth"
+
+
+# ── Initialization ───────────────────────────────────────────────────────────
+
+class TestInit:
+
+    def test_basic_init(self):
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        assert client.base_url == BASE_URL
+        assert client.token == "tok"
+        assert client.api_base_url is None
+        assert client.timeout == 120
+        assert client.verify_ssl is True
+        client.close()
+
+    def test_strips_trailing_slash(self):
+        client = BaseEkoClient(base_url=f"{BASE_URL}/", token="tok")
+        assert client.base_url == BASE_URL
+        client.close()
+
+    def test_dual_url(self):
+        client = BaseEkoClient(
+            base_url=BASE_URL, api_base_url=API_BASE_URL, token="tok"
+        )
+        assert client.api_base_url == API_BASE_URL
+        client.close()
+
+    def test_custom_timeout_and_ssl(self):
+        client = BaseEkoClient(
+            base_url=BASE_URL, token="tok", timeout=30, verify_ssl=False
+        )
+        assert client.timeout == 30
+        assert client.verify_ssl is False
+        client.close()
+
+    @respx.mock
+    def test_auto_login_with_credentials(self):
+        respx.post(f"{BASE_URL}/api/auth/login/").mock(
+            return_value=httpx.Response(200, json={"token": "auto-tok"})
+        )
+        client = BaseEkoClient(
+            base_url=BASE_URL, username="user", password="pass"
+        )
+        assert client.token == "auto-tok"
+        client.close()
+
+    def test_no_auto_login_without_credentials(self):
+        client = BaseEkoClient(base_url=BASE_URL)
+        assert client.token is None
+        client.close()
+
+
+# ── URL Resolution ───────────────────────────────────────────────────────────
+
+class TestResolveBaseUrl:
+
+    def test_single_url_always_returns_base(self):
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        assert client._resolve_base_url("/api/v1/esg/data/") == BASE_URL
+        assert client._resolve_base_url("/api/auth/login/") == BASE_URL
+        client.close()
+
+    def test_dual_url_routes_auth_to_base(self):
+        client = BaseEkoClient(
+            base_url=BASE_URL, api_base_url=API_BASE_URL, token="tok"
+        )
+        assert client._resolve_base_url("/api/auth/login/") == BASE_URL
+        assert client._resolve_base_url("/api/auth/user/") == BASE_URL
+        client.close()
+
+    def test_dual_url_routes_data_to_api(self):
+        client = BaseEkoClient(
+            base_url=BASE_URL, api_base_url=API_BASE_URL, token="tok"
+        )
+        assert client._resolve_base_url("/api/v1/esg/data/") == API_BASE_URL
+        assert client._resolve_base_url("/api/v1/management/jobs/") == API_BASE_URL
+        client.close()
+
+
+# ── Headers ──────────────────────────────────────────────────────────────────
+
+class TestHeaders:
+
+    def test_headers_with_token(self):
+        client = BaseEkoClient(base_url=BASE_URL, token="my-token")
+        headers = client._get_headers()
+        assert headers["Authorization"] == "Token my-token"
+        assert headers["Content-Type"] == "application/json"
+        assert headers["Accept"] == "application/json"
+        client.close()
+
+    def test_headers_without_token(self):
+        client = BaseEkoClient(base_url=BASE_URL)
+        headers = client._get_headers()
+        assert "Authorization" not in headers
+        client.close()
+
+
+# ── Response Handling ────────────────────────────────────────────────────────
+
+class TestHandleResponse:
+
+    def _make_response(self, status_code, body=None, text=""):
+        """Build a minimal httpx.Response for testing."""
+        if body is not None:
+            return httpx.Response(status_code, json=body)
+        return httpx.Response(status_code, text=text)
+
+    def test_success_json(self):
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        resp = self._make_response(200, {"results": [1, 2]})
+        assert client._handle_response(resp) == {"results": [1, 2]}
+        client.close()
+
+    def test_success_non_json(self):
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        resp = httpx.Response(200, text="plain text", headers={"content-type": "text/plain"})
+        result = client._handle_response(resp)
+        assert result == {"content": "plain text"}
+        client.close()
+
+    def test_401_raises_auth_error(self):
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        resp = self._make_response(401, {"error": "Invalid token"})
+        with pytest.raises(EkoAuthenticationError) as exc_info:
+            client._handle_response(resp)
+        assert exc_info.value.status_code == 401
+        client.close()
+
+    def test_404_raises_not_found(self):
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        resp = self._make_response(404, {"error": "Not found"})
+        with pytest.raises(EkoNotFoundError) as exc_info:
+            client._handle_response(resp)
+        assert exc_info.value.status_code == 404
+        client.close()
+
+    def test_429_raises_rate_limit(self):
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        resp = self._make_response(429, {"error": "Too many", "retry_after": "60"})
+        with pytest.raises(EkoRateLimitError) as exc_info:
+            client._handle_response(resp)
+        assert exc_info.value.retry_after == 60
+        client.close()
+
+    def test_429_without_retry_after(self):
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        resp = self._make_response(429, {"error": "Too many"})
+        with pytest.raises(EkoRateLimitError) as exc_info:
+            client._handle_response(resp)
+        assert exc_info.value.retry_after is None
+        client.close()
+
+    def test_500_raises_api_error(self):
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        resp = self._make_response(500, {"error": "Internal"})
+        with pytest.raises(EkoAPIError) as exc_info:
+            client._handle_response(resp)
+        assert exc_info.value.status_code == 500
+        client.close()
+
+    def test_error_with_non_json_body(self):
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        resp = httpx.Response(500, text="Server Error", headers={"content-type": "text/plain"})
+        with pytest.raises(EkoAPIError):
+            client._handle_response(resp)
+        client.close()
+
+
+# ── Sync Request ─────────────────────────────────────────────────────────────
+
+class TestRequestSync:
+
+    @respx.mock
+    def test_get_request(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/health/").mock(
+            return_value=httpx.Response(200, json={"status": "ok"})
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        result = client._request_sync("GET", "/api/v1/esg/health/")
+        assert result == {"status": "ok"}
+        client.close()
+
+    @respx.mock
+    def test_post_request_with_json(self):
+        respx.post(f"{BASE_URL}/api/auth/login/").mock(
+            return_value=httpx.Response(200, json={"token": "abc"})
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        result = client._request_sync(
+            "POST", "/api/auth/login/",
+            json_data={"username": "u", "password": "p"},
+        )
+        assert result == {"token": "abc"}
+        client.close()
+
+    @respx.mock
+    def test_get_with_params(self):
+        route = respx.get(f"{BASE_URL}/api/v1/esg/data/").mock(
+            return_value=httpx.Response(200, json={"results": []})
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        client._request_sync("GET", "/api/v1/esg/data/", params={"limit": 10})
+        assert route.called
+        client.close()
+
+    @respx.mock
+    def test_http_error_raises_client_error(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/health/").mock(
+            side_effect=httpx.ConnectError("connection refused")
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        with pytest.raises(EkoClientError, match="HTTP request failed"):
+            client._request_sync("GET", "/api/v1/esg/health/")
+        client.close()
+
+
+# ── Async Request ────────────────────────────────────────────────────────────
+
+class TestRequestAsync:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_request(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/health/").mock(
+            return_value=httpx.Response(200, json={"status": "ok"})
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        result = await client._request_async("GET", "/api/v1/esg/health/")
+        assert result == {"status": "ok"}
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_post_request(self):
+        respx.post(f"{BASE_URL}/api/auth/login/").mock(
+            return_value=httpx.Response(200, json={"token": "abc"})
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        result = await client._request_async(
+            "POST", "/api/auth/login/",
+            json_data={"username": "u", "password": "p"},
+        )
+        assert result == {"token": "abc"}
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_http_error_raises_client_error(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/health/").mock(
+            side_effect=httpx.ConnectError("refused")
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        with pytest.raises(EkoClientError, match="HTTP request failed"):
+            await client._request_async("GET", "/api/v1/esg/health/")
+        await client.close_async()
+
+
+# ── Login / Logout ───────────────────────────────────────────────────────────
+
+class TestLogin:
+
+    @respx.mock
+    def test_login_success(self):
+        respx.post(f"{BASE_URL}/api/auth/login/").mock(
+            return_value=httpx.Response(200, json={"token": "new-tok"})
+        )
+        client = BaseEkoClient(base_url=BASE_URL)
+        token = client.login("user", "pass")
+        assert token == "new-tok"
+        assert client.token == "new-tok"
+        client.close()
+
+    @respx.mock
+    def test_login_no_token_in_response(self):
+        respx.post(f"{BASE_URL}/api/auth/login/").mock(
+            return_value=httpx.Response(200, json={"message": "ok"})
+        )
+        client = BaseEkoClient(base_url=BASE_URL)
+        with pytest.raises(EkoAuthenticationError, match="No token received"):
+            client.login("user", "pass")
+        client.close()
+
+    @respx.mock
+    def test_login_api_error(self):
+        respx.post(f"{BASE_URL}/api/auth/login/").mock(
+            return_value=httpx.Response(400, json={"error": "bad creds"})
+        )
+        client = BaseEkoClient(base_url=BASE_URL)
+        with pytest.raises(EkoAuthenticationError, match="Login failed"):
+            client.login("user", "wrong")
+        client.close()
+
+
+class TestLogout:
+
+    @respx.mock
+    def test_logout_clears_token(self):
+        respx.post(f"{BASE_URL}/api/auth/logout/").mock(
+            return_value=httpx.Response(200, json={"status": "ok"})
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        client.logout()
+        assert client.token is None
+
+    def test_logout_no_token_is_noop(self):
+        client = BaseEkoClient(base_url=BASE_URL)
+        client.logout()  # should not raise
+        assert client.token is None
+
+    @respx.mock
+    def test_logout_ignores_errors(self):
+        respx.post(f"{BASE_URL}/api/auth/logout/").mock(
+            return_value=httpx.Response(500, json={"error": "fail"})
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        client.logout()  # should not raise
+        assert client.token is None
+
+
+# ── Close / Context Manager ──────────────────────────────────────────────────
+
+class TestClose:
+
+    def test_close_sync(self):
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        # Force creation of sync client
+        _ = client._get_sync_client()
+        assert client._sync_client is not None
+        client.close_sync()
+        assert client._sync_client is None
+
+    @pytest.mark.asyncio
+    async def test_close_async(self):
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        _ = client._get_async_client()
+        assert client._async_client is not None
+        await client.close_async()
+        assert client._async_client is None
+
+    def test_close_calls_close_sync(self):
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        _ = client._get_sync_client()
+        client.close()
+        assert client._sync_client is None
+
+    def test_context_manager(self):
+        with BaseEkoClient(base_url=BASE_URL, token="tok") as client:
+            _ = client._get_sync_client()
+            assert client._sync_client is not None
+        assert client._sync_client is None
+
+
+# ── Client Lazy Creation ─────────────────────────────────────────────────────
+
+class TestClientCreation:
+
+    def test_sync_client_created_lazily(self):
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        assert client._sync_client is None
+        sc = client._get_sync_client()
+        assert sc is not None
+        assert isinstance(sc, httpx.Client)
+        # Same instance on second call
+        assert client._get_sync_client() is sc
+        client.close()
+
+    def test_async_client_created_lazily(self):
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        assert client._async_client is None
+        ac = client._get_async_client()
+        assert ac is not None
+        assert isinstance(ac, httpx.AsyncClient)
+        assert client._get_async_client() is ac
+        client.close()

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,131 @@
+"""Tests for eko_client.exceptions — all custom exception classes."""
+
+import pytest
+from eko_client.exceptions import (
+    EkoClientError,
+    EkoAuthenticationError,
+    EkoAPIError,
+    EkoRateLimitError,
+    EkoSessionExpiredError,
+    EkoNotFoundError,
+)
+
+
+class TestEkoClientError:
+
+    def test_message_stored(self):
+        err = EkoClientError("something broke")
+        assert err.message == "something broke"
+        assert str(err) == "something broke"
+
+    def test_defaults(self):
+        err = EkoClientError("x")
+        assert err.status_code is None
+        assert err.response_data == {}
+
+    def test_custom_fields(self):
+        err = EkoClientError("x", status_code=500, response_data={"k": "v"})
+        assert err.status_code == 500
+        assert err.response_data == {"k": "v"}
+
+    def test_is_exception(self):
+        with pytest.raises(EkoClientError):
+            raise EkoClientError("boom")
+
+
+class TestEkoAuthenticationError:
+
+    def test_inherits_client_error(self):
+        assert issubclass(EkoAuthenticationError, EkoClientError)
+
+    def test_message(self):
+        err = EkoAuthenticationError("bad creds")
+        assert err.message == "bad creds"
+
+
+class TestEkoAPIError:
+
+    def test_inherits_client_error(self):
+        assert issubclass(EkoAPIError, EkoClientError)
+
+    def test_requires_status_code(self):
+        err = EkoAPIError("server error", status_code=500)
+        assert err.status_code == 500
+
+    def test_response_data(self):
+        err = EkoAPIError("x", status_code=400, response_data={"detail": "bad"})
+        assert err.response_data == {"detail": "bad"}
+
+
+class TestEkoRateLimitError:
+
+    def test_inherits_api_error(self):
+        assert issubclass(EkoRateLimitError, EkoAPIError)
+
+    def test_status_code_is_429(self):
+        err = EkoRateLimitError("slow down")
+        assert err.status_code == 429
+
+    def test_retry_after(self):
+        err = EkoRateLimitError("slow down", retry_after=30)
+        assert err.retry_after == 30
+
+    def test_retry_after_default_none(self):
+        err = EkoRateLimitError("slow down")
+        assert err.retry_after is None
+
+
+class TestEkoSessionExpiredError:
+
+    def test_inherits_authentication_error(self):
+        assert issubclass(EkoSessionExpiredError, EkoAuthenticationError)
+
+    def test_default_message(self):
+        err = EkoSessionExpiredError()
+        assert "Session expired" in err.message
+
+    def test_custom_message(self):
+        err = EkoSessionExpiredError("custom msg")
+        assert err.message == "custom msg"
+
+
+class TestEkoNotFoundError:
+
+    def test_inherits_api_error(self):
+        assert issubclass(EkoNotFoundError, EkoAPIError)
+
+    def test_status_code_is_404(self):
+        err = EkoNotFoundError()
+        assert err.status_code == 404
+
+    def test_default_message(self):
+        err = EkoNotFoundError()
+        assert err.message == "Resource not found"
+
+    def test_custom_message(self):
+        err = EkoNotFoundError("no such thing")
+        assert err.message == "no such thing"
+
+
+class TestExceptionHierarchy:
+    """Verify that except clauses catch the right subclasses."""
+
+    def test_catch_client_error_catches_auth(self):
+        with pytest.raises(EkoClientError):
+            raise EkoAuthenticationError("x")
+
+    def test_catch_client_error_catches_api(self):
+        with pytest.raises(EkoClientError):
+            raise EkoAPIError("x", status_code=500)
+
+    def test_catch_api_error_catches_rate_limit(self):
+        with pytest.raises(EkoAPIError):
+            raise EkoRateLimitError("x")
+
+    def test_catch_api_error_catches_not_found(self):
+        with pytest.raises(EkoAPIError):
+            raise EkoNotFoundError("x")
+
+    def test_catch_auth_error_catches_session_expired(self):
+        with pytest.raises(EkoAuthenticationError):
+            raise EkoSessionExpiredError()

--- a/tests/test_jwt_auth.py
+++ b/tests/test_jwt_auth.py
@@ -1,0 +1,822 @@
+"""Tests for eko_client.jwt_auth — JwtAuthMixin."""
+
+import pytest
+import httpx
+import respx
+from unittest.mock import patch
+
+from eko_client.user_client import EkoUserClient
+from eko_client.exceptions import (
+    EkoAuthenticationError,
+    EkoAPIError,
+    EkoSessionExpiredError,
+)
+
+BASE_URL = "https://test.jana.earth"
+
+
+# ── Header Override ──────────────────────────────────────────────────────────
+
+class TestJwtHeaders:
+
+    def test_bearer_token_used_when_access_token_set(self):
+        client = EkoUserClient(base_url=BASE_URL, token="drf-tok")
+        client.access_token = "jwt-access-tok"
+        headers = client._get_headers()
+        assert headers["Authorization"] == "Bearer jwt-access-tok"
+        client.close()
+
+    def test_drf_token_fallback(self):
+        client = EkoUserClient(base_url=BASE_URL, token="drf-tok")
+        headers = client._get_headers()
+        assert headers["Authorization"] == "Token drf-tok"
+        client.close()
+
+    def test_no_auth_header_when_no_tokens(self):
+        client = EkoUserClient(base_url=BASE_URL)
+        # Manually clear to avoid auto-login path
+        client.token = None
+        client.access_token = None
+        headers = client._get_headers()
+        assert "Authorization" not in headers
+        client.close()
+
+
+# ── login_password ───────────────────────────────────────────────────────────
+
+class TestLoginPassword:
+
+    @respx.mock
+    def test_success(self):
+        respx.post(f"{BASE_URL}/api/auth/login/").mock(
+            return_value=httpx.Response(200, json={
+                "data": {
+                    "access_token": "jwt-access",
+                    "refresh_token": "jwt-refresh",
+                }
+            })
+        )
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.login_password("user@test.com", "pass123")
+        assert client.access_token == "jwt-access"
+        assert client.refresh_token == "jwt-refresh"
+        client.close()
+
+    @respx.mock
+    def test_flat_response_no_data_wrapper(self):
+        respx.post(f"{BASE_URL}/api/auth/login/").mock(
+            return_value=httpx.Response(200, json={
+                "access_token": "jwt-flat",
+                "refresh_token": "jwt-flat-r",
+            })
+        )
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.login_password("user@test.com", "pass123")
+        assert client.access_token == "jwt-flat"
+        client.close()
+
+    @respx.mock
+    def test_no_access_token_raises(self):
+        respx.post(f"{BASE_URL}/api/auth/login/").mock(
+            return_value=httpx.Response(200, json={"data": {"message": "ok"}})
+        )
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        with pytest.raises(EkoAuthenticationError, match="No access_token"):
+            client.login_password("user@test.com", "pass123")
+        client.close()
+
+    @respx.mock
+    def test_api_error_wrapped(self):
+        respx.post(f"{BASE_URL}/api/auth/login/").mock(
+            return_value=httpx.Response(400, json={"error": "bad request"})
+        )
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        with pytest.raises(EkoAuthenticationError, match="Login failed"):
+            client.login_password("user@test.com", "wrong")
+        client.close()
+
+
+# ── login_password_async ─────────────────────────────────────────────────────
+
+class TestLoginPasswordAsync:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_success(self):
+        respx.post(f"{BASE_URL}/api/auth/login/").mock(
+            return_value=httpx.Response(200, json={
+                "data": {"access_token": "jwt-a", "refresh_token": "jwt-r"}
+            })
+        )
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        await client.login_password_async("u@t.com", "p")
+        assert client.access_token == "jwt-a"
+        assert client.refresh_token == "jwt-r"
+        await client.close_async()
+
+
+# ── refresh_jwt ──────────────────────────────────────────────────────────────
+
+class TestRefreshJwt:
+
+    @respx.mock
+    def test_success(self):
+        respx.post(f"{BASE_URL}/api/auth/refresh/").mock(
+            return_value=httpx.Response(200, json={
+                "data": {"access_token": "new-access", "refresh_token": "new-refresh"}
+            })
+        )
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.refresh_token = "old-refresh"
+        client.refresh_jwt()
+        assert client.access_token == "new-access"
+        assert client.refresh_token == "new-refresh"
+        client.close()
+
+    @respx.mock
+    def test_no_rotated_refresh(self):
+        """Server doesn't rotate refresh token — old one kept."""
+        respx.post(f"{BASE_URL}/api/auth/refresh/").mock(
+            return_value=httpx.Response(200, json={
+                "data": {"access_token": "new-access"}
+            })
+        )
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.refresh_token = "old-refresh"
+        client.refresh_jwt()
+        assert client.access_token == "new-access"
+        assert client.refresh_token == "old-refresh"
+        client.close()
+
+    def test_no_refresh_token_raises(self):
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.refresh_token = None
+        with pytest.raises(EkoAuthenticationError, match="No refresh token"):
+            client.refresh_jwt()
+        client.close()
+
+    @respx.mock
+    def test_api_error_wrapped(self):
+        """refresh_jwt via JwtAuthMixin._request_sync auto-refresh path
+        converts the 401 into EkoSessionExpiredError."""
+        respx.post(f"{BASE_URL}/api/auth/refresh/").mock(
+            return_value=httpx.Response(401, json={"error": "invalid"})
+        )
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.refresh_token = "bad-refresh"
+        with pytest.raises(EkoSessionExpiredError):
+            client.refresh_jwt()
+        client.close()
+
+    @respx.mock
+    def test_non_auth_error_wrapped(self):
+        """refresh_jwt wraps non-auth API errors (e.g. 400) into
+        EkoAuthenticationError — covers jwt_auth.py line 337."""
+        respx.post(f"{BASE_URL}/api/auth/refresh/").mock(
+            return_value=httpx.Response(400, json={"error": "Bad payload"})
+        )
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.refresh_token = "some-refresh"
+        with pytest.raises(EkoAuthenticationError, match="Token refresh failed"):
+            client.refresh_jwt()
+        client.close()
+
+
+# ── refresh_jwt_async ────────────────────────────────────────────────────────
+
+class TestRefreshJwtAsync:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_success(self):
+        respx.post(f"{BASE_URL}/api/auth/refresh/").mock(
+            return_value=httpx.Response(200, json={
+                "data": {"access_token": "new-a"}
+            })
+        )
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.refresh_token = "r"
+        await client.refresh_jwt_async()
+        assert client.access_token == "new-a"
+        await client.close_async()
+
+    @pytest.mark.asyncio
+    async def test_no_refresh_token_raises(self):
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.refresh_token = None
+        with pytest.raises(EkoAuthenticationError, match="No refresh token"):
+            await client.refresh_jwt_async()
+        await client.close_async()
+
+
+# ── _is_auth_failure ─────────────────────────────────────────────────────────
+
+class TestIsAuthFailure:
+
+    def test_authentication_error_is_auth_failure(self):
+        exc = EkoAuthenticationError("bad")
+        assert EkoUserClient._is_auth_failure(exc) is True
+
+    def test_403_with_token_keyword(self):
+        exc = EkoAPIError("Forbidden", status_code=403, response_data={"detail": "Token expired"})
+        assert EkoUserClient._is_auth_failure(exc) is True
+
+    def test_403_with_jwt_keyword(self):
+        exc = EkoAPIError("Forbidden", status_code=403, response_data={"detail": "Invalid JWT"})
+        assert EkoUserClient._is_auth_failure(exc) is True
+
+    def test_403_with_credentials_keyword(self):
+        exc = EkoAPIError("Forbidden", status_code=403, response_data={"detail": "Invalid credentials"})
+        assert EkoUserClient._is_auth_failure(exc) is True
+
+    def test_403_without_jwt_keywords(self):
+        exc = EkoAPIError("Forbidden", status_code=403, response_data={"detail": "Permission denied"})
+        assert EkoUserClient._is_auth_failure(exc) is False
+
+    def test_500_is_not_auth_failure(self):
+        exc = EkoAPIError("Server error", status_code=500)
+        assert EkoUserClient._is_auth_failure(exc) is False
+
+    def test_generic_exception_is_not_auth_failure(self):
+        exc = ValueError("unrelated")
+        assert EkoUserClient._is_auth_failure(exc) is False
+
+
+# ── Auto-refresh on 401/403 ─────────────────────────────────────────────────
+
+class TestAutoRefresh:
+
+    @respx.mock
+    def test_sync_auto_refresh_on_401(self):
+        """First request gets 401, refresh succeeds, retry succeeds."""
+        call_count = {"n": 0}
+
+        def health_handler(request):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return httpx.Response(401, json={"error": "Invalid token"})
+            return httpx.Response(200, json={"status": "ok"})
+
+        respx.get(f"{BASE_URL}/api/v1/esg/health/").mock(side_effect=health_handler)
+        respx.post(f"{BASE_URL}/api/auth/refresh/").mock(
+            return_value=httpx.Response(200, json={
+                "data": {"access_token": "refreshed-tok"}
+            })
+        )
+
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.access_token = "expired-tok"
+        client.refresh_token = "valid-refresh"
+        result = client._request_sync("GET", "/api/v1/esg/health/")
+        assert result == {"status": "ok"}
+        assert client.access_token == "refreshed-tok"
+        client.close()
+
+    @respx.mock
+    def test_sync_session_expired_when_refresh_fails(self):
+        """401 + refresh fails = EkoSessionExpiredError."""
+        respx.get(f"{BASE_URL}/api/v1/esg/health/").mock(
+            return_value=httpx.Response(401, json={"error": "Invalid token"})
+        )
+        respx.post(f"{BASE_URL}/api/auth/refresh/").mock(
+            return_value=httpx.Response(401, json={"error": "Refresh invalid"})
+        )
+
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.access_token = "expired"
+        client.refresh_token = "also-expired"
+        with pytest.raises(EkoSessionExpiredError):
+            client._request_sync("GET", "/api/v1/esg/health/")
+        assert client.access_token is None
+        assert client.refresh_token is None
+        client.close()
+
+    @respx.mock
+    def test_sync_session_expired_when_no_refresh_token(self):
+        """401 with no refresh token = EkoSessionExpiredError."""
+        respx.get(f"{BASE_URL}/api/v1/esg/health/").mock(
+            return_value=httpx.Response(401, json={"error": "Invalid token"})
+        )
+
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.access_token = "expired"
+        client.refresh_token = None
+        with pytest.raises(EkoSessionExpiredError):
+            client._request_sync("GET", "/api/v1/esg/health/")
+        client.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_auto_refresh_on_401(self):
+        call_count = {"n": 0}
+
+        def health_handler(request):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return httpx.Response(401, json={"error": "Invalid token"})
+            return httpx.Response(200, json={"status": "ok"})
+
+        respx.get(f"{BASE_URL}/api/v1/esg/health/").mock(side_effect=health_handler)
+        respx.post(f"{BASE_URL}/api/auth/refresh/").mock(
+            return_value=httpx.Response(200, json={
+                "data": {"access_token": "refreshed"}
+            })
+        )
+
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.access_token = "expired"
+        client.refresh_token = "valid"
+        result = await client._request_async("GET", "/api/v1/esg/health/")
+        assert result == {"status": "ok"}
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_session_expired(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/health/").mock(
+            return_value=httpx.Response(401, json={"error": "Invalid"})
+        )
+        respx.post(f"{BASE_URL}/api/auth/refresh/").mock(
+            return_value=httpx.Response(401, json={"error": "Bad refresh"})
+        )
+
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.access_token = "expired"
+        client.refresh_token = "bad"
+        with pytest.raises(EkoSessionExpiredError):
+            await client._request_async("GET", "/api/v1/esg/health/")
+        await client.close_async()
+
+    @respx.mock
+    def test_non_auth_error_not_retried(self):
+        """A 500 error is not retried."""
+        respx.get(f"{BASE_URL}/api/v1/esg/health/").mock(
+            return_value=httpx.Response(500, json={"error": "Internal"})
+        )
+
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.access_token = "tok"
+        client.refresh_token = "ref"
+        with pytest.raises(EkoAPIError) as exc_info:
+            client._request_sync("GET", "/api/v1/esg/health/")
+        assert exc_info.value.status_code == 500
+        client.close()
+
+
+# ── get_user_info ────────────────────────────────────────────────────────────
+
+class TestGetUserInfo:
+
+    @respx.mock
+    def test_sync_unwraps_data(self):
+        respx.get(f"{BASE_URL}/api/auth/user/").mock(
+            return_value=httpx.Response(200, json={
+                "data": {"username": "dev-user", "email": "dev@test.com"}
+            })
+        )
+        client = EkoUserClient(base_url=BASE_URL, token="tok")
+        info = client.get_user_info()
+        assert info["username"] == "dev-user"
+        client.close()
+
+    @respx.mock
+    def test_sync_flat_response(self):
+        respx.get(f"{BASE_URL}/api/auth/user/").mock(
+            return_value=httpx.Response(200, json={
+                "username": "dev-user", "email": "dev@test.com"
+            })
+        )
+        client = EkoUserClient(base_url=BASE_URL, token="tok")
+        info = client.get_user_info()
+        assert info["username"] == "dev-user"
+        client.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_unwraps_data(self):
+        respx.get(f"{BASE_URL}/api/auth/user/").mock(
+            return_value=httpx.Response(200, json={
+                "data": {"username": "u"}
+            })
+        )
+        client = EkoUserClient(base_url=BASE_URL, token="tok")
+        info = await client.get_user_info_async()
+        assert info["username"] == "u"
+        await client.close_async()
+
+
+# ── is_authenticated ─────────────────────────────────────────────────────────
+
+class TestIsAuthenticated:
+
+    def test_true_when_access_token(self):
+        client = EkoUserClient(base_url=BASE_URL, token="tok")
+        client.access_token = "jwt-tok"
+        assert client.is_authenticated() is True
+        client.close()
+
+    def test_false_when_no_access_token(self):
+        client = EkoUserClient(base_url=BASE_URL, token="tok")
+        client.access_token = None
+        assert client.is_authenticated() is False
+        client.close()
+
+
+# ── login_password_async error paths ────────────────────────────────────────
+
+class TestLoginPasswordAsyncErrors:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_api_error_wrapped(self):
+        """Async login_password wraps API errors."""
+        respx.post(f"{BASE_URL}/api/auth/login/").mock(
+            return_value=httpx.Response(400, json={"error": "bad"})
+        )
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        with pytest.raises(EkoAuthenticationError, match="Login failed"):
+            await client.login_password_async("u@t.com", "wrong")
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_no_access_token_raises(self):
+        """Async login_password raises when no access_token in response."""
+        respx.post(f"{BASE_URL}/api/auth/login/").mock(
+            return_value=httpx.Response(200, json={"data": {"message": "ok"}})
+        )
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        with pytest.raises(EkoAuthenticationError, match="No access_token"):
+            await client.login_password_async("u@t.com", "p")
+        await client.close_async()
+
+
+# ── refresh_jwt_async error paths ───────────────────────────────────────────
+
+class TestRefreshJwtAsyncErrors:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_api_error_wrapped(self):
+        """Async refresh_jwt wraps API error into EkoSessionExpiredError
+        (goes through auto-refresh wrapper)."""
+        respx.post(f"{BASE_URL}/api/auth/refresh/").mock(
+            return_value=httpx.Response(401, json={"error": "invalid"})
+        )
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.refresh_token = "bad"
+        with pytest.raises(EkoSessionExpiredError):
+            await client.refresh_jwt_async()
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_non_auth_error_wrapped(self):
+        """Async: non-auth API error (400) wraps into EkoAuthenticationError
+        — covers jwt_auth.py line 365."""
+        respx.post(f"{BASE_URL}/api/auth/refresh/").mock(
+            return_value=httpx.Response(400, json={"error": "Bad payload"})
+        )
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.refresh_token = "some-refresh"
+        with pytest.raises(EkoAuthenticationError, match="Token refresh failed"):
+            await client.refresh_jwt_async()
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_rotated_refresh_token(self):
+        """Async refresh_jwt picks up rotated refresh token."""
+        respx.post(f"{BASE_URL}/api/auth/refresh/").mock(
+            return_value=httpx.Response(200, json={
+                "data": {"access_token": "new-a", "refresh_token": "new-r"}
+            })
+        )
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.refresh_token = "old"
+        await client.refresh_jwt_async()
+        assert client.access_token == "new-a"
+        assert client.refresh_token == "new-r"
+        await client.close_async()
+
+
+# ── Async auto-refresh: no refresh token ────────────────────────────────────
+
+class TestAutoRefreshAsyncNoRefreshToken:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_session_expired_when_no_refresh_token(self):
+        """Async: 401 with no refresh token = EkoSessionExpiredError."""
+        respx.get(f"{BASE_URL}/api/v1/esg/health/").mock(
+            return_value=httpx.Response(401, json={"error": "Invalid token"})
+        )
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.access_token = "expired"
+        client.refresh_token = None
+        with pytest.raises(EkoSessionExpiredError):
+            await client._request_async("GET", "/api/v1/esg/health/")
+        await client.close_async()
+
+
+# ── login_device (sync) ─────────────────────────────────────────────────────
+
+class TestLoginDevice:
+
+    @respx.mock
+    @patch("eko_client.jwt_auth.webbrowser.open")
+    @patch("eko_client.jwt_auth.time.sleep")
+    def test_success_immediate_approval(self, mock_sleep, mock_browser):
+        """Device code issued, first poll returns tokens."""
+        respx.post(f"{BASE_URL}/api/auth/device-code/").mock(
+            return_value=httpx.Response(200, json={
+                "data": {
+                    "device_code": "dev-123",
+                    "user_code": "ABCD-1234",
+                    "verification_uri_complete": "https://auth.jana.earth/verify?code=ABCD-1234",
+                    "interval": 1,
+                }
+            })
+        )
+        respx.post(f"{BASE_URL}/api/auth/device-token/").mock(
+            return_value=httpx.Response(200, json={
+                "data": {
+                    "access_token": "device-access",
+                    "refresh_token": "device-refresh",
+                }
+            })
+        )
+
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.login_device()
+        assert client.access_token == "device-access"
+        assert client.refresh_token == "device-refresh"
+        mock_browser.assert_called_once()
+        mock_sleep.assert_called_once_with(1)
+        client.close()
+
+    @respx.mock
+    @patch("eko_client.jwt_auth.webbrowser.open")
+    @patch("eko_client.jwt_auth.time.sleep")
+    def test_pending_then_approved(self, mock_sleep, mock_browser):
+        """Two polls: first pending, second approved."""
+        respx.post(f"{BASE_URL}/api/auth/device-code/").mock(
+            return_value=httpx.Response(200, json={
+                "device_code": "dev-456",
+                "user_code": "XYZ",
+                "verification_uri": "https://auth.jana.earth/verify",
+                "interval": 2,
+            })
+        )
+        call_count = {"n": 0}
+
+        def token_handler(request):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return httpx.Response(400, json={"error": "authorization_pending"})
+            return httpx.Response(200, json={
+                "access_token": "dev-tok", "refresh_token": "dev-ref",
+            })
+
+        respx.post(f"{BASE_URL}/api/auth/device-token/").mock(side_effect=token_handler)
+
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.login_device()
+        assert client.access_token == "dev-tok"
+        assert mock_sleep.call_count == 2
+        client.close()
+
+    @respx.mock
+    @patch("eko_client.jwt_auth.webbrowser.open")
+    @patch("eko_client.jwt_auth.time.sleep")
+    def test_slow_down_increases_interval(self, mock_sleep, mock_browser):
+        """slow_down response increases the polling interval."""
+        respx.post(f"{BASE_URL}/api/auth/device-code/").mock(
+            return_value=httpx.Response(200, json={
+                "device_code": "dev-789",
+                "verification_uri": "https://auth.jana.earth/verify",
+                "interval": 3,
+            })
+        )
+        call_count = {"n": 0}
+
+        def token_handler(request):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return httpx.Response(400, json={
+                    "error": "slow_down", "interval": 10,
+                })
+            return httpx.Response(200, json={
+                "access_token": "tok", "refresh_token": "ref",
+            })
+
+        respx.post(f"{BASE_URL}/api/auth/device-token/").mock(side_effect=token_handler)
+
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.login_device()
+        # First sleep(3), then slow_down sets interval=10, second sleep(10)
+        assert mock_sleep.call_args_list[0][0][0] == 3
+        assert mock_sleep.call_args_list[1][0][0] == 10
+        client.close()
+
+    @respx.mock
+    @patch("eko_client.jwt_auth.webbrowser.open")
+    @patch("eko_client.jwt_auth.time.sleep")
+    def test_terminal_error(self, mock_sleep, mock_browser):
+        """Terminal error (e.g. access_denied) raises EkoAuthenticationError."""
+        respx.post(f"{BASE_URL}/api/auth/device-code/").mock(
+            return_value=httpx.Response(200, json={
+                "device_code": "dev-err",
+                "verification_uri": "https://auth.jana.earth/verify",
+            })
+        )
+        respx.post(f"{BASE_URL}/api/auth/device-token/").mock(
+            return_value=httpx.Response(400, json={"error": "access_denied"})
+        )
+
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        with pytest.raises(EkoAuthenticationError, match="Device login failed"):
+            client.login_device()
+        client.close()
+
+    @respx.mock
+    def test_device_code_request_failure(self):
+        """API error on device-code step raises EkoAuthenticationError."""
+        respx.post(f"{BASE_URL}/api/auth/device-code/").mock(
+            return_value=httpx.Response(500, json={"error": "Internal"})
+        )
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        with pytest.raises(EkoAuthenticationError, match="Failed to request device code"):
+            client.login_device()
+        client.close()
+
+    @respx.mock
+    @patch("eko_client.jwt_auth.webbrowser.open", side_effect=OSError("no browser"))
+    @patch("eko_client.jwt_auth.time.sleep")
+    def test_browser_open_failure_non_fatal(self, mock_sleep, mock_browser):
+        """webbrowser.open failure is non-fatal — login continues."""
+        respx.post(f"{BASE_URL}/api/auth/device-code/").mock(
+            return_value=httpx.Response(200, json={
+                "device_code": "dev-nobrowser",
+                "verification_uri": "https://auth.jana.earth/verify",
+            })
+        )
+        respx.post(f"{BASE_URL}/api/auth/device-token/").mock(
+            return_value=httpx.Response(200, json={
+                "access_token": "tok", "refresh_token": "ref",
+            })
+        )
+
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        client.login_device()
+        assert client.access_token == "tok"
+        client.close()
+
+
+# ── login_device_async ──────────────────────────────────────────────────────
+
+class TestLoginDeviceAsync:
+
+    @respx.mock
+    @patch("eko_client.jwt_auth.webbrowser.open")
+    @patch("eko_client.jwt_auth.asyncio.sleep")
+    @pytest.mark.asyncio
+    async def test_success_immediate(self, mock_sleep, mock_browser):
+        """Async device login: immediate approval."""
+        respx.post(f"{BASE_URL}/api/auth/device-code/").mock(
+            return_value=httpx.Response(200, json={
+                "data": {
+                    "device_code": "adev-123",
+                    "verification_uri_complete": "https://auth.jana.earth/verify?code=X",
+                    "interval": 1,
+                }
+            })
+        )
+        respx.post(f"{BASE_URL}/api/auth/device-token/").mock(
+            return_value=httpx.Response(200, json={
+                "data": {"access_token": "async-tok", "refresh_token": "async-ref"}
+            })
+        )
+
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        await client.login_device_async()
+        assert client.access_token == "async-tok"
+        assert client.refresh_token == "async-ref"
+        await client.close_async()
+
+    @respx.mock
+    @patch("eko_client.jwt_auth.webbrowser.open")
+    @patch("eko_client.jwt_auth.asyncio.sleep")
+    @pytest.mark.asyncio
+    async def test_pending_then_approved(self, mock_sleep, mock_browser):
+        """Async: authorization_pending then success."""
+        respx.post(f"{BASE_URL}/api/auth/device-code/").mock(
+            return_value=httpx.Response(200, json={
+                "device_code": "adev-456",
+                "verification_uri": "https://auth.jana.earth/verify",
+                "interval": 2,
+            })
+        )
+        call_count = {"n": 0}
+
+        def handler(request):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return httpx.Response(400, json={"error": "authorization_pending"})
+            return httpx.Response(200, json={
+                "access_token": "async-ok", "refresh_token": "async-r",
+            })
+
+        respx.post(f"{BASE_URL}/api/auth/device-token/").mock(side_effect=handler)
+
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        await client.login_device_async()
+        assert client.access_token == "async-ok"
+        await client.close_async()
+
+    @respx.mock
+    @patch("eko_client.jwt_auth.webbrowser.open")
+    @patch("eko_client.jwt_auth.asyncio.sleep")
+    @pytest.mark.asyncio
+    async def test_slow_down(self, mock_sleep, mock_browser):
+        """Async: slow_down increases interval."""
+        respx.post(f"{BASE_URL}/api/auth/device-code/").mock(
+            return_value=httpx.Response(200, json={
+                "device_code": "adev-slow",
+                "verification_uri": "https://auth.jana.earth/verify",
+                "interval": 2,
+            })
+        )
+        call_count = {"n": 0}
+
+        def handler(request):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return httpx.Response(400, json={"error": "slow_down", "interval": 15})
+            return httpx.Response(200, json={
+                "access_token": "tok", "refresh_token": "ref",
+            })
+
+        respx.post(f"{BASE_URL}/api/auth/device-token/").mock(side_effect=handler)
+
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        await client.login_device_async()
+        assert mock_sleep.call_args_list[0][0][0] == 2
+        assert mock_sleep.call_args_list[1][0][0] == 15
+        await client.close_async()
+
+    @respx.mock
+    @patch("eko_client.jwt_auth.webbrowser.open")
+    @patch("eko_client.jwt_auth.asyncio.sleep")
+    @pytest.mark.asyncio
+    async def test_terminal_error(self, mock_sleep, mock_browser):
+        """Async: terminal error raises EkoAuthenticationError."""
+        respx.post(f"{BASE_URL}/api/auth/device-code/").mock(
+            return_value=httpx.Response(200, json={
+                "device_code": "adev-err",
+                "verification_uri": "https://auth.jana.earth/verify",
+            })
+        )
+        respx.post(f"{BASE_URL}/api/auth/device-token/").mock(
+            return_value=httpx.Response(400, json={"error": "expired_token"})
+        )
+
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        with pytest.raises(EkoAuthenticationError, match="Device login failed"):
+            await client.login_device_async()
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_device_code_request_failure(self):
+        """Async: API error on device-code step."""
+        respx.post(f"{BASE_URL}/api/auth/device-code/").mock(
+            return_value=httpx.Response(500, json={"error": "Internal"})
+        )
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        with pytest.raises(EkoAuthenticationError, match="Failed to request device code"):
+            await client.login_device_async()
+        await client.close_async()
+
+    @respx.mock
+    @patch("eko_client.jwt_auth.webbrowser.open", side_effect=OSError("no browser"))
+    @patch("eko_client.jwt_auth.asyncio.sleep")
+    @pytest.mark.asyncio
+    async def test_browser_open_failure_non_fatal(self, mock_sleep, mock_browser):
+        """Async: browser failure is non-fatal."""
+        respx.post(f"{BASE_URL}/api/auth/device-code/").mock(
+            return_value=httpx.Response(200, json={
+                "device_code": "adev-nobr",
+                "verification_uri": "https://auth.jana.earth/verify",
+            })
+        )
+        respx.post(f"{BASE_URL}/api/auth/device-token/").mock(
+            return_value=httpx.Response(200, json={
+                "access_token": "tok", "refresh_token": "ref",
+            })
+        )
+
+        client = EkoUserClient(base_url=BASE_URL, token="tmp")
+        await client.login_device_async()
+        assert client.access_token == "tok"
+        await client.close_async()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,360 @@
+"""Tests for eko_client.models — Pydantic model validation."""
+
+from datetime import datetime
+from eko_client.models import (
+    QueryMetadata,
+    QualityFlag,
+    QualitySummary,
+    Attribution,
+    AirQualityMeasurement,
+    EmissionMeasurement,
+    UnifiedDataResponse,
+    AggregationResponse,
+    CorrelationResponse,
+    TrendResponse,
+    QualityResponse,
+    AlertResponse,
+    Alert,
+    LocationResponse,
+    UnifiedLocation,
+    ExportResponse,
+    ExportStatusResponse,
+    DefinitionsResponse,
+    ParameterDefinitionsResponse,
+    ParameterDefinition,
+    UnitDefinitionsResponse,
+    UnitDefinition,
+    UnitConversion,
+    SourceDefinitionsResponse,
+    SourceDefinition,
+    HealthResponse,
+    SystemHealthResponse,
+    PlatformSummaryResponse,
+    AggregatedMeasurement,
+    SpatialCorrelation,
+    TemporalCorrelation,
+    ParameterCorrelation,
+    TrendAnalysis,
+    SeasonalPattern,
+    Anomaly,
+    Forecast,
+)
+
+
+class TestQueryMetadata:
+
+    def test_from_dict(self):
+        m = QueryMetadata(sources=["openaq"], total_records=100)
+        assert m.sources == ["openaq"]
+        assert m.total_records == 100
+
+    def test_all_optional(self):
+        m = QueryMetadata()
+        assert m.sources is None
+
+
+class TestQualityFlag:
+
+    def test_from_dict(self):
+        f = QualityFlag(flag_type="outlier", severity="high")
+        assert f.flag_type == "outlier"
+
+
+class TestQualitySummary:
+
+    def test_with_flags(self):
+        s = QualitySummary(overall_score=85, completeness=0.95)
+        assert s.overall_score == 85
+
+
+class TestAttribution:
+
+    def test_from_dict(self):
+        a = Attribution(openaq="CC-BY-4.0")
+        assert a.openaq == "CC-BY-4.0"
+
+
+class TestAirQualityMeasurement:
+
+    def test_full_record(self):
+        m = AirQualityMeasurement(
+            location_id=1,
+            parameter="pm25",
+            value=35.0,
+            unit="ug/m3",
+            timestamp=datetime(2024, 1, 1),
+            coordinates=[85.3, 27.7],
+            source="openaq",
+        )
+        assert m.value == 35.0
+        assert m.coordinates == [85.3, 27.7]
+
+
+class TestEmissionMeasurement:
+
+    def test_full_record(self):
+        m = EmissionMeasurement(
+            asset_id=100,
+            parameter="co2",
+            value=1234.5,
+            sector="energy",
+        )
+        assert m.sector == "energy"
+
+
+class TestUnifiedDataResponse:
+
+    def test_minimal(self):
+        r = UnifiedDataResponse()
+        assert r.data is None
+
+    def test_with_data(self):
+        r = UnifiedDataResponse(
+            data={"air_quality": [{"id": 1}]},
+            metadata=QueryMetadata(total_records=1),
+        )
+        assert r.data["air_quality"][0]["id"] == 1
+
+
+class TestAggregationResponse:
+
+    def test_minimal(self):
+        r = AggregationResponse(aggregations={"daily": []})
+        assert r.aggregations == {"daily": []}
+
+
+class TestAggregatedMeasurement:
+
+    def test_from_dict(self):
+        m = AggregatedMeasurement(parameter="pm25", temporal_resolution="daily")
+        assert m.temporal_resolution == "daily"
+
+
+class TestSpatialCorrelation:
+
+    def test_from_dict(self):
+        c = SpatialCorrelation(distance_km=10.5, correlation_coefficient=0.85)
+        assert c.distance_km == 10.5
+
+
+class TestTemporalCorrelation:
+
+    def test_from_dict(self):
+        c = TemporalCorrelation(parameter_1="pm25", parameter_2="co2", lag_days=7)
+        assert c.lag_days == 7
+
+
+class TestParameterCorrelation:
+
+    def test_from_dict(self):
+        c = ParameterCorrelation(parameter_1="pm25", sample_size=1000)
+        assert c.sample_size == 1000
+
+
+class TestCorrelationResponse:
+
+    def test_minimal(self):
+        r = CorrelationResponse(correlations={"spatial": []})
+        assert "spatial" in r.correlations
+
+
+class TestTrendAnalysis:
+
+    def test_from_dict(self):
+        t = TrendAnalysis(parameter="pm25", trend_direction="increasing", slope=0.5)
+        assert t.slope == 0.5
+
+
+class TestSeasonalPattern:
+
+    def test_from_dict(self):
+        p = SeasonalPattern(pattern_type="annual", amplitude=10.0)
+        assert p.amplitude == 10.0
+
+
+class TestAnomaly:
+
+    def test_from_dict(self):
+        a = Anomaly(anomaly_score=3.5, anomaly_type="spike", severity="high")
+        assert a.severity == "high"
+
+
+class TestForecast:
+
+    def test_from_dict(self):
+        f = Forecast(parameter="pm25", forecast_horizon=30)
+        assert f.forecast_horizon == 30
+
+
+class TestTrendResponse:
+
+    def test_with_all_sections(self):
+        r = TrendResponse(
+            trends=[TrendAnalysis(parameter="pm25")],
+            anomalies=[Anomaly(anomaly_score=2.0)],
+            forecasts=[Forecast(forecast_horizon=7)],
+        )
+        assert len(r.trends) == 1
+        assert len(r.anomalies) == 1
+
+
+class TestQualityResponse:
+
+    def test_minimal(self):
+        r = QualityResponse(recommendations=["Add more sensors"])
+        assert len(r.recommendations) == 1
+
+
+class TestAlert:
+
+    def test_from_dict(self):
+        a = Alert(
+            id="alert-1",
+            type="quality",
+            severity="high",
+            status="active",
+            title="Data gap",
+        )
+        assert a.title == "Data gap"
+
+
+class TestAlertResponse:
+
+    def test_with_alerts(self):
+        r = AlertResponse(
+            alerts=[Alert(id="1")],
+            total_count=1,
+            active_count=1,
+        )
+        assert r.total_count == 1
+
+
+class TestUnifiedLocation:
+
+    def test_from_dict(self):
+        loc = UnifiedLocation(
+            id=1,
+            name="Kathmandu",
+            coordinates=[85.3, 27.7],
+            country_code="NPL",
+            source="openaq",
+        )
+        assert loc.name == "Kathmandu"
+
+
+class TestLocationResponse:
+
+    def test_with_locations(self):
+        r = LocationResponse(
+            locations=[UnifiedLocation(id=1)],
+            total_count=1,
+        )
+        assert r.total_count == 1
+
+
+class TestExportResponse:
+
+    def test_from_dict(self):
+        r = ExportResponse(export_id="abc", status="processing")
+        assert r.export_id == "abc"
+
+
+class TestExportStatusResponse:
+
+    def test_from_dict(self):
+        r = ExportStatusResponse(export_id="abc", status="completed")
+        assert r.status == "completed"
+
+
+class TestParameterDefinition:
+
+    def test_from_dict(self):
+        p = ParameterDefinition(
+            parameter="pm25",
+            display_name="PM2.5",
+            unit="ug/m3",
+            sources=["openaq"],
+        )
+        assert p.display_name == "PM2.5"
+
+
+class TestParameterDefinitionsResponse:
+
+    def test_from_dict(self):
+        r = ParameterDefinitionsResponse(
+            parameters=[ParameterDefinition(parameter="pm25")],
+            total_count=1,
+        )
+        assert r.total_count == 1
+
+
+class TestUnitDefinition:
+
+    def test_from_dict(self):
+        u = UnitDefinition(unit="ug/m3", display_name="Micrograms per cubic meter")
+        assert u.unit == "ug/m3"
+
+
+class TestUnitConversion:
+
+    def test_from_dict(self):
+        c = UnitConversion(from_unit="mg/m3", to_unit="ug/m3", conversion_factor=1000.0)
+        assert c.conversion_factor == 1000.0
+
+
+class TestUnitDefinitionsResponse:
+
+    def test_from_dict(self):
+        r = UnitDefinitionsResponse(
+            units=[UnitDefinition(unit="ug/m3")],
+            conversions=[UnitConversion(from_unit="mg/m3", to_unit="ug/m3")],
+        )
+        assert len(r.units) == 1
+
+
+class TestSourceDefinition:
+
+    def test_from_dict(self):
+        s = SourceDefinition(source="openaq", display_name="OpenAQ")
+        assert s.source == "openaq"
+
+
+class TestSourceDefinitionsResponse:
+
+    def test_from_dict(self):
+        r = SourceDefinitionsResponse(sources=[SourceDefinition(source="openaq")])
+        assert len(r.sources) == 1
+
+
+class TestDefinitionsResponse:
+
+    def test_from_dict(self):
+        r = DefinitionsResponse(total_parameters=50, total_units=10, total_sources=3)
+        assert r.total_parameters == 50
+
+
+class TestHealthResponse:
+
+    def test_from_dict(self):
+        r = HealthResponse(service="esg-api", status="ok")
+        assert r.status == "ok"
+
+
+class TestSystemHealthResponse:
+
+    def test_from_dict(self):
+        r = SystemHealthResponse(
+            system_status={"overall_health": "ok"},
+            recommendations=["Scale up workers"],
+        )
+        assert r.system_status["overall_health"] == "ok"
+
+
+class TestPlatformSummaryResponse:
+
+    def test_from_dict(self):
+        r = PlatformSummaryResponse(
+            platform_overview={"total_records": 1000000},
+            generated_at=datetime(2024, 6, 15),
+        )
+        assert r.platform_overview["total_records"] == 1000000

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,398 @@
+"""Tests for BaseEkoClient.fetch_all_pages and fetch_all_pages_async."""
+
+import pytest
+import httpx
+import respx
+
+from eko_client.client import BaseEkoClient
+
+BASE_URL = "https://test.jana.earth"
+
+
+def _page(results, count=None, next_url=None):
+    """Build a paginated response dict."""
+    d = {"results": results}
+    if count is not None:
+        d["count"] = count
+    if next_url is not None:
+        d["next"] = next_url
+    return d
+
+
+# ── fetch_all_pages (sync) ───────────────────────────────────────────────────
+
+class TestFetchAllPagesSync:
+
+    @respx.mock
+    def test_single_page_with_count(self):
+        """Page-number pagination: one page, count present."""
+        respx.get(f"{BASE_URL}/api/v1/data/").mock(
+            return_value=httpx.Response(200, json=_page(
+                [{"id": 1}, {"id": 2}], count=2,
+            ))
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        results = client.fetch_all_pages("/api/v1/data/", page_size=100)
+        assert len(results) == 2
+        assert results[0]["id"] == 1
+        client.close()
+
+    @respx.mock
+    def test_multi_page_with_count(self):
+        """Page-number pagination: two pages via next URL."""
+        respx.get(f"{BASE_URL}/api/v1/data/").mock(
+            side_effect=[
+                httpx.Response(200, json=_page(
+                    [{"id": 1}], count=2,
+                    next_url=f"{BASE_URL}/api/v1/data/?page=2&page_size=1",
+                )),
+                httpx.Response(200, json=_page(
+                    [{"id": 2}], count=2,
+                )),
+            ]
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        results = client.fetch_all_pages("/api/v1/data/", page_size=1)
+        assert len(results) == 2
+        client.close()
+
+    @respx.mock
+    def test_cursor_pagination_no_count(self):
+        """Cursor pagination: no count field, uses next URL."""
+        respx.get(f"{BASE_URL}/api/v1/data/").mock(
+            side_effect=[
+                httpx.Response(200, json=_page(
+                    [{"id": 1}],
+                    next_url=f"{BASE_URL}/api/v1/data/?cursor=abc",
+                )),
+                httpx.Response(200, json=_page([{"id": 2}])),
+            ]
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        results = client.fetch_all_pages("/api/v1/data/", page_size=1)
+        assert len(results) == 2
+        client.close()
+
+    @respx.mock
+    def test_empty_first_page(self):
+        """Empty results on first page returns empty list."""
+        respx.get(f"{BASE_URL}/api/v1/data/").mock(
+            return_value=httpx.Response(200, json=_page([], count=0))
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        results = client.fetch_all_pages("/api/v1/data/")
+        assert results == []
+        client.close()
+
+    @respx.mock
+    def test_max_pages_limit(self, capsys):
+        """Stops at max_pages even if more data exists."""
+        respx.get(f"{BASE_URL}/api/v1/data/").mock(
+            side_effect=[
+                httpx.Response(200, json=_page(
+                    [{"id": i}],
+                    next_url=f"{BASE_URL}/api/v1/data/?cursor=page{i+1}",
+                ))
+                for i in range(5)
+            ]
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        results = client.fetch_all_pages(
+            "/api/v1/data/", page_size=1, max_pages=3, progress=True,
+        )
+        assert len(results) == 3
+        captured = capsys.readouterr()
+        assert "max page limit" in captured.out.lower()
+        client.close()
+
+    @respx.mock
+    def test_sends_both_page_size_and_limit(self):
+        """Verify first request sends both page_size and limit params."""
+        route = respx.get(f"{BASE_URL}/api/v1/data/").mock(
+            return_value=httpx.Response(200, json=_page([], count=0))
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        client.fetch_all_pages("/api/v1/data/", page_size=500)
+        req = route.calls[0].request
+        assert "page_size" in str(req.url)
+        assert "limit" in str(req.url)
+        client.close()
+
+    @respx.mock
+    def test_preserves_existing_params(self):
+        """User-supplied params are preserved and not overwritten."""
+        route = respx.get(f"{BASE_URL}/api/v1/data/").mock(
+            return_value=httpx.Response(200, json=_page([], count=0))
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        client.fetch_all_pages(
+            "/api/v1/data/",
+            params={"country_code": "NPL", "page_size": 50},
+            page_size=1000,
+        )
+        req = route.calls[0].request
+        url_str = str(req.url)
+        assert "country_code=NPL" in url_str
+        # User's page_size=50 takes precedence over the default 1000
+        assert "page_size=50" in url_str
+        client.close()
+
+    @respx.mock
+    def test_progress_output_page_number(self, capsys):
+        """Progress output for page-number pagination shows count."""
+        respx.get(f"{BASE_URL}/api/v1/data/").mock(
+            return_value=httpx.Response(200, json=_page(
+                [{"id": 1}, {"id": 2}], count=2,
+            ))
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        client.fetch_all_pages("/api/v1/data/", progress=True)
+        captured = capsys.readouterr()
+        assert "2 total records" in captured.out
+        assert "Done: 2 records" in captured.out
+        client.close()
+
+    @respx.mock
+    def test_progress_output_cursor(self, capsys):
+        """Progress output for cursor pagination detects 'no count'."""
+        respx.get(f"{BASE_URL}/api/v1/data/").mock(
+            return_value=httpx.Response(200, json=_page(
+                [{"id": 1}],
+            ))
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        client.fetch_all_pages("/api/v1/data/", progress=True)
+        captured = capsys.readouterr()
+        assert "Cursor pagination" in captured.out
+        client.close()
+
+    @respx.mock
+    def test_no_progress_when_disabled(self, capsys):
+        """progress=False produces no output."""
+        respx.get(f"{BASE_URL}/api/v1/data/").mock(
+            return_value=httpx.Response(200, json=_page(
+                [{"id": 1}], count=1,
+            ))
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        client.fetch_all_pages("/api/v1/data/", progress=False)
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        client.close()
+
+    @respx.mock
+    def test_stops_when_all_results_fetched(self):
+        """Stops when len(results) >= count even if next exists."""
+        respx.get(f"{BASE_URL}/api/v1/data/").mock(
+            return_value=httpx.Response(200, json=_page(
+                [{"id": 1}, {"id": 2}], count=2,
+                next_url=f"{BASE_URL}/api/v1/data/?page=2",
+            ))
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        results = client.fetch_all_pages("/api/v1/data/")
+        assert len(results) == 2
+        client.close()
+
+    @respx.mock
+    def test_no_next_url_stops(self):
+        """Cursor pagination without next URL stops."""
+        respx.get(f"{BASE_URL}/api/v1/data/").mock(
+            return_value=httpx.Response(200, json=_page([{"id": 1}]))
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        results = client.fetch_all_pages("/api/v1/data/")
+        assert len(results) == 1
+        client.close()
+
+
+# ── fetch_all_pages_async ────────────────────────────────────────────────────
+
+class TestFetchAllPagesAsync:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_single_page(self):
+        respx.get(f"{BASE_URL}/api/v1/data/").mock(
+            return_value=httpx.Response(200, json=_page(
+                [{"id": 1}], count=1,
+            ))
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        results = await client.fetch_all_pages_async("/api/v1/data/")
+        assert len(results) == 1
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_multi_page_cursor(self):
+        respx.get(f"{BASE_URL}/api/v1/data/").mock(
+            side_effect=[
+                httpx.Response(200, json=_page(
+                    [{"id": 1}],
+                    next_url=f"{BASE_URL}/api/v1/data/?cursor=xyz",
+                )),
+                httpx.Response(200, json=_page([{"id": 2}])),
+            ]
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        results = await client.fetch_all_pages_async("/api/v1/data/", page_size=1)
+        assert len(results) == 2
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_empty_results(self):
+        respx.get(f"{BASE_URL}/api/v1/data/").mock(
+            return_value=httpx.Response(200, json=_page([], count=0))
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        results = await client.fetch_all_pages_async("/api/v1/data/")
+        assert results == []
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_max_pages(self, capsys):
+        respx.get(f"{BASE_URL}/api/v1/data/").mock(
+            side_effect=[
+                httpx.Response(200, json=_page(
+                    [{"id": i}],
+                    next_url=f"{BASE_URL}/api/v1/data/?cursor=p{i+1}",
+                ))
+                for i in range(5)
+            ]
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        results = await client.fetch_all_pages_async(
+            "/api/v1/data/", page_size=1, max_pages=2, progress=True,
+        )
+        assert len(results) == 2
+        captured = capsys.readouterr()
+        assert "max page limit" in captured.out.lower()
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_progress_output(self, capsys):
+        respx.get(f"{BASE_URL}/api/v1/data/").mock(
+            return_value=httpx.Response(200, json=_page(
+                [{"id": 1}], count=1,
+            ))
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        await client.fetch_all_pages_async("/api/v1/data/", progress=True)
+        captured = capsys.readouterr()
+        assert "Done:" in captured.out
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_sends_both_params(self):
+        route = respx.get(f"{BASE_URL}/api/v1/data/").mock(
+            return_value=httpx.Response(200, json=_page([], count=0))
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        await client.fetch_all_pages_async("/api/v1/data/", page_size=250)
+        req = route.calls[0].request
+        assert "page_size" in str(req.url)
+        assert "limit" in str(req.url)
+        await client.close_async()
+
+
+# ── _pagination_progress static method ───────────────────────────────────────
+
+class TestPaginationProgress:
+
+    def test_no_output_when_disabled(self, capsys):
+        BaseEkoClient._pagination_progress(1, 10, 100, False, False)
+        assert capsys.readouterr().out == ""
+
+    def test_detected_cursor(self, capsys):
+        BaseEkoClient._pagination_progress(
+            1, 10, None, True, True, _detected=True,
+        )
+        out = capsys.readouterr().out
+        assert "Cursor pagination" in out
+
+    def test_detected_page_number(self, capsys):
+        BaseEkoClient._pagination_progress(
+            1, 10, 500, False, True, _detected=True,
+        )
+        out = capsys.readouterr().out
+        assert "500 total records" in out
+
+    def test_periodic_progress_with_count(self, capsys):
+        BaseEkoClient._pagination_progress(5, 250, 1000, False, True, progress_every=5)
+        out = capsys.readouterr().out
+        assert "page 5" in out
+        assert "250" in out
+        assert "25%" in out
+
+    def test_periodic_progress_cursor(self, capsys):
+        BaseEkoClient._pagination_progress(10, 500, None, True, True, progress_every=5)
+        out = capsys.readouterr().out
+        assert "page 10" in out
+        assert "500" in out
+
+    def test_non_periodic_page_skipped(self, capsys):
+        BaseEkoClient._pagination_progress(3, 100, 1000, False, True, progress_every=5)
+        assert capsys.readouterr().out == ""
+
+
+# ── Edge cases for no-next-url break path ───────────────────────────────────
+
+class TestFetchAllPagesNoNextUrl:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_no_next_url_stops(self):
+        """Async: results but no next URL — breaks at line 412."""
+        respx.get(f"{BASE_URL}/api/v1/data/").mock(
+            return_value=httpx.Response(200, json=_page([{"id": 1}]))
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        results = await client.fetch_all_pages_async("/api/v1/data/")
+        assert len(results) == 1
+        await client.close_async()
+
+    @respx.mock
+    def test_sync_no_next_url_with_results_but_no_count(self):
+        """Sync: results present, no count, no next URL — hits line 498 break."""
+        respx.get(f"{BASE_URL}/api/v1/data/").mock(
+            return_value=httpx.Response(200, json={
+                "results": [{"id": 1}, {"id": 2}],
+                # no "count" key, no "next" key
+            })
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        results = client.fetch_all_pages("/api/v1/data/")
+        assert len(results) == 2
+        client.close()
+
+
+# ── max_pages logger.warning path ───────────────────────────────────────────
+
+class TestMaxPagesWarningAsync:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_max_pages_limit(self, capsys):
+        """Async: stops at max_pages and prints warning — covers line 396-397."""
+        respx.get(f"{BASE_URL}/api/v1/data/").mock(
+            side_effect=[
+                httpx.Response(200, json=_page(
+                    [{"id": i}],
+                    next_url=f"{BASE_URL}/api/v1/data/?cursor=page{i+1}",
+                ))
+                for i in range(5)
+            ]
+        )
+        client = BaseEkoClient(base_url=BASE_URL, token="tok")
+        results = await client.fetch_all_pages_async(
+            "/api/v1/data/", page_size=1, max_pages=3, progress=True,
+        )
+        assert len(results) == 3
+        captured = capsys.readouterr()
+        assert "max page limit" in captured.out.lower()
+        await client.close_async()

--- a/tests/test_sync_wrapper.py
+++ b/tests/test_sync_wrapper.py
@@ -1,0 +1,204 @@
+"""Tests for eko_client.sync_wrapper — auto_sync_wrapper decorator."""
+
+import asyncio
+import pytest
+from eko_client.sync_wrapper import auto_sync_wrapper, _create_sync_wrapper
+
+
+class TestAutoSyncWrapper:
+
+    def test_generates_sync_methods(self):
+        """Decorator creates sync methods for async methods."""
+        @auto_sync_wrapper
+        class MyClient:
+            async def fetch_data_async(self, param: str) -> dict:
+                """Fetch data."""
+                return {"param": param}
+
+        client = MyClient()
+        assert hasattr(client, "fetch_data")
+        assert callable(client.fetch_data)
+
+    def test_sync_method_calls_async(self):
+        """Generated sync method actually calls the async method."""
+        @auto_sync_wrapper
+        class MyClient:
+            async def greet_async(self, name: str) -> str:
+                return f"Hello, {name}"
+
+        client = MyClient()
+        result = client.greet(name="World")
+        assert result == "Hello, World"
+
+    def test_preserves_docstring(self):
+        @auto_sync_wrapper
+        class MyClient:
+            async def fetch_async(self) -> dict:
+                """Fetch all the things."""
+                return {}
+
+        assert MyClient.fetch.__doc__ == "Fetch all the things."
+
+    def test_no_docstring_generates_one(self):
+        @auto_sync_wrapper
+        class MyClient:
+            async def fetch_async(self):
+                return {}
+
+        assert "fetch_async" in MyClient.fetch.__doc__
+
+    def test_skips_non_async_suffix(self):
+        """Methods not ending in _async are not wrapped."""
+        @auto_sync_wrapper
+        class MyClient:
+            def regular_method(self):
+                return "regular"
+
+            async def helper_internal(self):
+                return "no suffix"
+
+        client = MyClient()
+        assert hasattr(client, "regular_method")
+        assert not hasattr(client, "helper_internal_sync")
+
+    def test_skips_existing_sync_method(self):
+        """If sync method already exists, don't overwrite it."""
+        @auto_sync_wrapper
+        class MyClient:
+            def get_data(self):
+                return "manual sync"
+
+            async def get_data_async(self):
+                return "async version"
+
+        client = MyClient()
+        assert client.get_data() == "manual sync"
+
+    def test_adds_close_sync_loop(self):
+        @auto_sync_wrapper
+        class MyClient:
+            async def fetch_async(self):
+                return {}
+
+        client = MyClient()
+        assert hasattr(client, "close_sync_loop")
+
+    def test_close_sync_loop_safe_without_loop(self):
+        """close_sync_loop doesn't error if no loop was created."""
+        @auto_sync_wrapper
+        class MyClient:
+            async def fetch_async(self):
+                return {}
+
+        client = MyClient()
+        client.close_sync_loop()  # should not raise
+
+    def test_close_sync_loop_closes_loop(self):
+        """close_sync_loop closes the event loop if it was created."""
+        @auto_sync_wrapper
+        class MyClient:
+            async def fetch_async(self):
+                return {}
+
+        client = MyClient()
+        # Force creation of _sync_loop by calling sync method
+        client.fetch()
+        if hasattr(client, "_sync_loop") and client._sync_loop:
+            assert not client._sync_loop.is_closed()
+            client.close_sync_loop()
+            assert client._sync_loop is None
+
+    def test_multiple_sequential_calls(self):
+        """Sync wrapper supports multiple sequential calls."""
+        @auto_sync_wrapper
+        class MyClient:
+            def __init__(self):
+                self.call_count = 0
+
+            async def increment_async(self) -> int:
+                self.call_count += 1
+                return self.call_count
+
+        client = MyClient()
+        assert client.increment() == 1
+        assert client.increment() == 2
+        assert client.increment() == 3
+
+    def test_preserves_annotations(self):
+        @auto_sync_wrapper
+        class MyClient:
+            async def fetch_async(self, limit: int = 10) -> dict:
+                return {"limit": limit}
+
+        # Check that annotations are preserved
+        annotations = MyClient.fetch.__annotations__
+        assert "limit" in annotations or "return" in annotations
+
+
+class TestCreateSyncWrapper:
+
+    def test_wraps_simple_coroutine(self):
+        async def my_async(self):
+            return 42
+
+        sync = _create_sync_wrapper(my_async)
+
+        class FakeClient:
+            pass
+
+        client = FakeClient()
+        result = sync(client)
+        assert result == 42
+
+    def test_nest_asyncio_path(self):
+        """When a running event loop exists, nest_asyncio is applied."""
+        import nest_asyncio
+
+        @auto_sync_wrapper
+        class MyClient:
+            async def fetch_async(self):
+                return "from-jupyter"
+
+        async def run_inside_loop():
+            client = MyClient()
+            # Calling sync method inside a running event loop triggers
+            # the nest_asyncio code path (lines 62-66)
+            result = client.fetch()
+            return result
+
+        # Apply nest_asyncio so run_until_complete can be re-entered
+        loop = asyncio.new_event_loop()
+        nest_asyncio.apply(loop)
+        try:
+            result = loop.run_until_complete(run_inside_loop())
+            assert result == "from-jupyter"
+        finally:
+            loop.close()
+
+    def test_non_coroutine_with_async_suffix_skipped(self):
+        """A regular (non-async) method ending in _async is not wrapped.
+        Covers sync_wrapper.py line 160 (the `continue` when
+        `not inspect.iscoroutinefunction(attr)`)."""
+        @auto_sync_wrapper
+        class MyClient:
+            def not_really_async(self):
+                return "sync"
+
+            # This is a regular function, not a coroutine, but ends in _async
+            pass
+
+        # Manually add a non-coroutine with _async suffix to verify
+        def fake_async(self):
+            return "fake"
+        fake_async.__name__ = "get_thing_async"
+
+        # Attach it before decorating a new class
+        @auto_sync_wrapper
+        class MyClient2:
+            pass
+
+        MyClient2.get_thing_async = fake_async
+        # Re-apply decorator to pick up the new attr
+        MyClient2 = auto_sync_wrapper(MyClient2)
+        # get_thing should NOT be created since get_thing_async is not a coroutine
+        assert not hasattr(MyClient2, "get_thing")

--- a/tests/test_user_client.py
+++ b/tests/test_user_client.py
@@ -1,0 +1,738 @@
+"""Tests for eko_client.user_client — EkoUserClient endpoint methods.
+
+Strategy: Each async method is the source of truth (the sync version is
+auto-generated). We test every async method with respx, and spot-check
+a few sync wrappers to verify auto_sync_wrapper works end-to-end.
+"""
+
+import pytest
+import httpx
+import respx
+from datetime import datetime
+
+from eko_client.user_client import EkoUserClient
+
+BASE_URL = "https://test.jana.earth"
+OK = {"results": [{"id": 1}], "count": 1}
+
+
+def _client():
+    return EkoUserClient(base_url=BASE_URL, token="tok")
+
+
+# ── Core Data Access ─────────────────────────────────────────────────────────
+
+class TestGetData:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_data_async_minimal(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/data/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_data_async()
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_data_async_all_params(self):
+        route = respx.get(f"{BASE_URL}/api/v1/esg/data/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        await client.get_data_async(
+            sources=["openaq", "edgar"],
+            location_bbox=[80, 26, 88, 30],
+            location_point=[85.3, 27.7],
+            radius_km=50.0,
+            country_codes=["NPL"],
+            date_from=datetime(2024, 1, 1),
+            date_to="2024-12-31",
+            temporal_resolution="daily",
+            parameters=["pm25"],
+            quality_threshold=80,
+            include_flags=True,
+            limit=100,
+            offset=0,
+        )
+        assert route.called
+        await client.close_async()
+
+    @respx.mock
+    def test_get_data_sync(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/data/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = client.get_data(sources=["openaq"], limit=10)
+        assert result == OK
+        client.close()
+
+
+class TestGetAggregations:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_basic(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/aggregations/").mock(
+            return_value=httpx.Response(200, json={"aggregations": {}})
+        )
+        client = _client()
+        result = await client.get_aggregations_async("daily")
+        assert "aggregations" in result
+        await client.close_async()
+
+
+# ── Analytics & Intelligence ─────────────────────────────────────────────────
+
+class TestGetCorrelations:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_basic(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/correlations/").mock(
+            return_value=httpx.Response(200, json={"correlations": {}})
+        )
+        client = _client()
+        result = await client.get_correlations_async(sources=["openaq", "edgar"])
+        assert "correlations" in result
+        await client.close_async()
+
+
+class TestGetTrends:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_basic(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/trends/").mock(
+            return_value=httpx.Response(200, json={"trends": []})
+        )
+        client = _client()
+        result = await client.get_trends_async(
+            sources=["openaq"],
+            date_from=datetime(2024, 1, 1),
+            date_to=datetime(2024, 6, 30),
+        )
+        assert "trends" in result
+        await client.close_async()
+
+
+# ── Quality & Monitoring ─────────────────────────────────────────────────────
+
+class TestGetQuality:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_basic(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/quality/").mock(
+            return_value=httpx.Response(200, json={"overall_quality": {}})
+        )
+        client = _client()
+        result = await client.get_quality_async(
+            date_from=datetime(2024, 1, 1),
+        )
+        assert "overall_quality" in result
+        await client.close_async()
+
+
+class TestGetAlerts:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_basic(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/alerts/").mock(
+            return_value=httpx.Response(200, json={"alerts": []})
+        )
+        client = _client()
+        result = await client.get_alerts_async(
+            alert_types=["quality"],
+            date_from=datetime(2024, 1, 1),
+        )
+        assert "alerts" in result
+        await client.close_async()
+
+
+# ── Geographic & Spatial ─────────────────────────────────────────────────────
+
+class TestGetGeojson:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_basic(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/geojson/").mock(
+            return_value=httpx.Response(200, json={"type": "FeatureCollection"})
+        )
+        client = _client()
+        result = await client.get_geojson_async(sources=["openaq"])
+        assert result["type"] == "FeatureCollection"
+        await client.close_async()
+
+
+class TestGetLocations:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_basic(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/locations/").mock(
+            return_value=httpx.Response(200, json={"locations": []})
+        )
+        client = _client()
+        result = await client.get_locations_async(limit=10)
+        assert "locations" in result
+        await client.close_async()
+
+
+# ── Export & Bulk Access ─────────────────────────────────────────────────────
+
+class TestExports:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_create_export(self):
+        respx.post(f"{BASE_URL}/api/v1/esg/exports/").mock(
+            return_value=httpx.Response(201, json={"export_id": "abc"})
+        )
+        client = _client()
+        result = await client.create_export_async(
+            format="csv",
+            query={"sources": ["openaq"]},
+            compression="gzip",
+            chunk_size=5000,
+            email_notification="test@test.com",
+            expires_in_hours=24,
+        )
+        assert result["export_id"] == "abc"
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_export_status(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/exports/abc/status/").mock(
+            return_value=httpx.Response(200, json={"status": "completed"})
+        )
+        client = _client()
+        result = await client.get_export_status_async("abc")
+        assert result["status"] == "completed"
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_download_export(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/exports/abc/download/").mock(
+            return_value=httpx.Response(200, content=b"csv,data,here")
+        )
+        client = _client()
+        content = await client.download_export_async("abc")
+        assert content == b"csv,data,here"
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_download_export_error(self):
+        """Error response on download triggers _handle_response (line 491)."""
+        from eko_client.exceptions import EkoNotFoundError
+        respx.get(f"{BASE_URL}/api/v1/esg/exports/bad/download/").mock(
+            return_value=httpx.Response(404, json={"error": "Not found"})
+        )
+        client = _client()
+        with pytest.raises(EkoNotFoundError):
+            await client.download_export_async("bad")
+        await client.close_async()
+
+
+# ── Metadata & Definitions ───────────────────────────────────────────────────
+
+class TestDefinitions:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_definitions(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/definitions/").mock(
+            return_value=httpx.Response(200, json={"categories": []})
+        )
+        client = _client()
+        result = await client.get_definitions_async()
+        assert "categories" in result
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_parameter_definitions(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/parameters/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_parameter_definitions_async(sources=["openaq"])
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_unit_definitions(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/definitions/units/").mock(
+            return_value=httpx.Response(200, json={"units": []})
+        )
+        client = _client()
+        result = await client.get_unit_definitions_async()
+        assert "units" in result
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_source_definitions(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/definitions/sources/").mock(
+            return_value=httpx.Response(200, json={"sources": []})
+        )
+        client = _client()
+        result = await client.get_source_definitions_async()
+        assert "sources" in result
+        await client.close_async()
+
+
+# ── System & Health ──────────────────────────────────────────────────────────
+
+class TestSystemHealth:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_health(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/health/").mock(
+            return_value=httpx.Response(200, json={"status": "ok"})
+        )
+        client = _client()
+        result = await client.get_health_async()
+        assert result["status"] == "ok"
+        await client.close_async()
+
+    @respx.mock
+    def test_get_health_sync(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/health/").mock(
+            return_value=httpx.Response(200, json={"status": "ok"})
+        )
+        client = _client()
+        result = client.get_health()
+        assert result["status"] == "ok"
+        client.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_system_health(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/system-health/").mock(
+            return_value=httpx.Response(200, json={"system_status": {}})
+        )
+        client = _client()
+        result = await client.get_system_health_async()
+        assert "system_status" in result
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_summary(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/summary/").mock(
+            return_value=httpx.Response(200, json={"platform_overview": {}})
+        )
+        client = _client()
+        result = await client.get_summary_async()
+        assert "platform_overview" in result
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_sectors(self):
+        respx.get(f"{BASE_URL}/api/v1/esg/sectors/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_sectors_async(
+            sources=["climatetrace"],
+            country_codes=["NPL"],
+            limit=100,
+            date_from=datetime(2024, 1, 1),
+            date_to="2024-12-31",
+        )
+        assert result == OK
+        await client.close_async()
+
+
+# ── OpenAQ Endpoints ─────────────────────────────────────────────────────────
+
+class TestOpenAQ:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_locations(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/openaq/locations/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_openaq_locations_async(country_codes="US", limit=10)
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_locations_list_country_codes(self):
+        route = respx.get(f"{BASE_URL}/api/v1/data-sources/openaq/locations/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        await client.get_openaq_locations_async(country_codes=["US", "GB"])
+        assert route.called
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_location_by_id(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/openaq/locations/42/").mock(
+            return_value=httpx.Response(200, json={"id": 42})
+        )
+        client = _client()
+        result = await client.get_openaq_location_async(42)
+        assert result["id"] == 42
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_sensors(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/openaq/sensors/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_openaq_sensors_async(
+            location_id=1,
+            parameter="pm25",
+            country_code="US",
+            location_bbox=[80, 26, 88, 30],
+            coordinates=[85.3, 27.7],
+            radius_km=10.0,
+            limit=5,
+        )
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_sensor_by_id(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/openaq/sensors/7/").mock(
+            return_value=httpx.Response(200, json={"id": 7})
+        )
+        client = _client()
+        result = await client.get_openaq_sensor_async(7)
+        assert result["id"] == 7
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_measurements(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/openaq/measurements/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_openaq_measurements_async(
+            parameter="pm25",
+            date_from=datetime(2024, 1, 1),
+            date_to="2024-06-30",
+            ordering="-measured_at",
+            page=1,
+            page_size=50,
+        )
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_measurement_by_id(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/openaq/measurements/99/").mock(
+            return_value=httpx.Response(200, json={"id": 99})
+        )
+        client = _client()
+        result = await client.get_openaq_measurement_async(99)
+        assert result["id"] == 99
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_measurements_date_range(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/openaq/measurements/date_range/").mock(
+            return_value=httpx.Response(200, json={"earliest_date": "2020-01-01"})
+        )
+        client = _client()
+        result = await client.get_openaq_measurements_date_range_async()
+        assert "earliest_date" in result
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_measurements_totals(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/openaq/measurements/totals/").mock(
+            return_value=httpx.Response(200, json={"record_count": 1000})
+        )
+        client = _client()
+        result = await client.get_openaq_measurements_totals_async()
+        assert result["record_count"] == 1000
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_measurements_parameter_totals(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/openaq/measurements/parameter_totals/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_openaq_measurements_parameter_totals_async()
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_measurements_country_totals(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/openaq/measurements/country_totals/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_openaq_measurements_country_totals_async()
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_parameters(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/openaq/parameters/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_openaq_parameters_async(limit=50)
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_parameter_by_id(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/openaq/parameters/3/").mock(
+            return_value=httpx.Response(200, json={"id": 3})
+        )
+        client = _client()
+        result = await client.get_openaq_parameter_async(3)
+        assert result["id"] == 3
+        await client.close_async()
+
+    @respx.mock
+    def test_get_locations_sync(self):
+        """Verify sync wrapper works for OpenAQ locations."""
+        respx.get(f"{BASE_URL}/api/v1/data-sources/openaq/locations/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = client.get_openaq_locations(limit=5)
+        assert result == OK
+        client.close()
+
+
+# ── Climate TRACE Endpoints ──────────────────────────────────────────────────
+
+class TestClimateTRACE:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_sectors(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/climatetrace/sectors/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_climatetrace_sectors_async(limit=100)
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_countries(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/climatetrace/countries/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_climatetrace_countries_async()
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_assets(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/climatetrace/assets/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_climatetrace_assets_async(
+            sector_id=1, country_code="NPL",
+        )
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_emissions(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/climatetrace/emissions/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_climatetrace_emissions_async(
+            country_code="NPL",
+            gas="co2",
+            date_from=datetime(2024, 1, 1),
+        )
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_emissions_date_range(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/climatetrace/emissions/date_range/").mock(
+            return_value=httpx.Response(200, json={"earliest_date": "2015-01-01"})
+        )
+        client = _client()
+        result = await client.get_climatetrace_emissions_date_range_async(country_code="NPL")
+        assert "earliest_date" in result
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_emissions_totals(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/climatetrace/emissions/totals/").mock(
+            return_value=httpx.Response(200, json={"total_co2e": 12345.6})
+        )
+        client = _client()
+        result = await client.get_climatetrace_emissions_totals_async(
+            date_from=datetime(2024, 1, 1),
+            date_to=datetime(2024, 12, 31),
+        )
+        assert "total_co2e" in result
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_emissions_sector_totals(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/climatetrace/emissions/sector_totals/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_climatetrace_emissions_sector_totals_async(
+            date_from=datetime(2024, 1, 1),
+        )
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_emissions_country_totals(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/climatetrace/emissions/country_totals/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_climatetrace_emissions_country_totals_async(
+            date_from=datetime(2024, 1, 1),
+        )
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_emissions_gas_type_distribution(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/climatetrace/emissions/gas_type_distribution/").mock(
+            return_value=httpx.Response(200, json={"gas_types": []})
+        )
+        client = _client()
+        result = await client.get_climatetrace_emissions_gas_type_distribution_async()
+        assert "gas_types" in result
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_company_matches(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/climatetrace/company-matches/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_climatetrace_company_matches_async(limit=5)
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_violations(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/climatetrace/violations/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_climatetrace_violations_async(limit=5)
+        assert result == OK
+        await client.close_async()
+
+
+# ── EDGAR Endpoints ──────────────────────────────────────────────────────────
+
+class TestEDGAR:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_country_totals(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/edgar/country-totals/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_edgar_country_totals_async(
+            country_code="USA", year=2023, gas="CO2",
+        )
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_grid_emissions(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/edgar/grid-emissions/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_edgar_grid_emissions_async(
+            year=2023, gas="CO2", min_value=1000,
+            bbox="80,26,88,30", coordinates="85.3,27.7", radius=50.0,
+        )
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_temporal_profiles(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/edgar/temporal-profiles/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_edgar_temporal_profiles_async(
+            sector="energy", temporal_level="monthly",
+        )
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_get_fasttrack(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/edgar/fasttrack/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_edgar_fasttrack_async(
+            year=2024, provisional=True,
+        )
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    def test_get_country_totals_sync(self):
+        """Verify sync wrapper works for EDGAR."""
+        respx.get(f"{BASE_URL}/api/v1/data-sources/edgar/country-totals/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = client.get_edgar_country_totals(country_code="NPL")
+        assert result == OK
+        client.close()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,115 @@
+"""Tests for eko_client.utils — format_query_params, parse_date, build_url."""
+
+from datetime import datetime
+from eko_client.utils import format_query_params, parse_date, build_url
+
+
+# ── format_query_params ──────────────────────────────────────────────────────
+
+class TestFormatQueryParams:
+
+    def test_strips_none_values(self):
+        result = format_query_params({"a": 1, "b": None, "c": "x"})
+        assert result == {"a": 1, "c": "x"}
+
+    def test_all_none_returns_empty(self):
+        assert format_query_params({"a": None, "b": None}) == {}
+
+    def test_empty_dict(self):
+        assert format_query_params({}) == {}
+
+    def test_list_to_comma_separated(self):
+        result = format_query_params({"sources": ["openaq", "edgar"]})
+        assert result == {"sources": "openaq,edgar"}
+
+    def test_tuple_to_comma_separated(self):
+        result = format_query_params({"sources": ("openaq", "edgar")})
+        assert result == {"sources": "openaq,edgar"}
+
+    def test_location_bbox_kept_as_list(self):
+        bbox = [1.0, 2.0, 3.0, 4.0]
+        result = format_query_params({"location_bbox": bbox})
+        assert result == {"location_bbox": bbox}
+
+    def test_location_point_kept_as_list(self):
+        point = [85.3, 27.7]
+        result = format_query_params({"location_point": point})
+        assert result == {"location_point": point}
+
+    def test_datetime_converted_to_isoformat(self):
+        dt = datetime(2024, 6, 15, 12, 0, 0)
+        result = format_query_params({"date_from": dt})
+        assert result == {"date_from": "2024-06-15T12:00:00"}
+
+    def test_bool_converted_to_lowercase_string(self):
+        result = format_query_params({"provisional": True, "active": False})
+        assert result == {"provisional": "true", "active": "false"}
+
+    def test_scalar_values_passed_through(self):
+        result = format_query_params({"year": 2023, "gas": "CO2", "limit": 100})
+        assert result == {"year": 2023, "gas": "CO2", "limit": 100}
+
+    def test_mixed_types(self):
+        result = format_query_params({
+            "sources": ["openaq"],
+            "location_bbox": [1, 2, 3, 4],
+            "year": 2023,
+            "provisional": True,
+            "date_from": datetime(2024, 1, 1),
+            "unused": None,
+        })
+        assert result == {
+            "sources": "openaq",
+            "location_bbox": [1, 2, 3, 4],
+            "year": 2023,
+            "provisional": "true",
+            "date_from": "2024-01-01T00:00:00",
+        }
+
+
+# ── parse_date ───────────────────────────────────────────────────────────────
+
+class TestParseDate:
+
+    def test_valid_iso_date(self):
+        result = parse_date("2024-06-15T12:00:00")
+        assert result == datetime(2024, 6, 15, 12, 0, 0)
+
+    def test_z_suffix_replaced(self):
+        result = parse_date("2024-06-15T12:00:00Z")
+        assert result is not None
+        assert result.year == 2024
+
+    def test_none_returns_none(self):
+        assert parse_date(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert parse_date("") is None
+
+    def test_invalid_string_returns_none(self):
+        assert parse_date("not-a-date") is None
+
+
+# ── build_url ────────────────────────────────────────────────────────────────
+
+class TestBuildUrl:
+
+    def test_simple_url(self):
+        result = build_url("https://api.test.com", "/api/v1/health/")
+        assert result == "https://api.test.com/api/v1/health/"
+
+    def test_strips_trailing_slash_from_base(self):
+        result = build_url("https://api.test.com/", "/api/v1/health/")
+        assert result == "https://api.test.com/api/v1/health/"
+
+    def test_strips_leading_slash_from_path(self):
+        result = build_url("https://api.test.com", "api/v1/health/")
+        assert result == "https://api.test.com/api/v1/health/"
+
+    def test_multiple_path_parts(self):
+        result = build_url("https://api.test.com", "/api/v1", "health/")
+        assert result == "https://api.test.com/api/v1/health/"
+
+    def test_empty_path_parts_skipped(self):
+        result = build_url("https://api.test.com", "", "/api/v1/health/")
+        assert result == "https://api.test.com/api/v1/health/"


### PR DESCRIPTION
## Summary
- Add 300 unit tests with 99.8% code coverage using respx HTTP mocking
- Cover all modules: BaseEkoClient, EkoUserClient, EkoAdminClient, JwtAuthMixin (including device code flow), AuthMixin, sync_wrapper, pagination, exceptions, models, utils
- Add Development section to README with setup, test run, and code style instructions
- Update pyproject.toml with pytest/coverage config and test dependencies

## Test plan
- [x] `pytest --cov=eko_client --cov-report=term-missing` — 300 passed, 99.81% coverage
- [x] All async and sync paths tested
- [x] JWT auto-refresh, device code flow, session expiry tested
- [x] Pagination (cursor + page-number) fully tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)