### PR TITLE
feat: add GCP and NOAA Storm Events data source methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jana Eko Client - Python Client Library for Jana Earth Unified Environmental Data API
 
-A Python client library for accessing the Jana Earth Unified Environmental Data API. This library provides easy access to environmental data from OpenAQ, Climate TRACE, and EDGAR sources through a clean, Pythonic interface.
+A Python client library for accessing the Jana Earth Unified Environmental Data API. This library provides easy access to environmental data from OpenAQ, Climate TRACE, EDGAR, GLEIF, GCP (Global Carbon Project), and NOAA Storm Events sources through a clean, Pythonic interface.
 
 ## Features
 
@@ -184,6 +184,23 @@ End-user client for accessing unified data APIs. Does not include job management
 - `get_edgar_grid_emissions()` - Get EDGAR grid emissions
 - `get_edgar_temporal_profiles()` - Get EDGAR temporal profiles
 - `get_edgar_fasttrack()` - Get EDGAR fasttrack data
+
+**GLEIF:**
+- `get_gleif_entities()` - Search/filter legal entities by name, country, status
+- `get_gleif_entity(lei)` - Get entity details by LEI
+- `get_gleif_entity_parents(lei)` - Get direct and ultimate parent entities
+- `get_gleif_entity_children(lei)` - Get subsidiary entities
+- `get_gleif_relationships()` - Query ownership/consolidation relationships
+- `get_gleif_exceptions()` - Get reporting exceptions
+
+**GCP (Global Carbon Project):**
+- `get_gcp_national_emissions()` - Get national CO2 emissions by country/year
+- `get_gcp_emissions_by_fuel()` - Get global fossil CO2 by fuel type (coal, oil, gas, cement)
+- `get_gcp_carbon_budget()` - Get global carbon budget components
+- `get_gcp_methane_budget()` - Get global methane budget components
+
+**NOAA (Storm Events):**
+- `get_noaa_storm_events()` - Get severe weather events (tornadoes, hurricanes, floods, etc.)
 
 ### EkoAdminClient
 

--- a/eko_client/user_client.py
+++ b/eko_client/user_client.py
@@ -1296,3 +1296,176 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
             'offset': offset,
         }
         return await self._request_async('GET', '/api/v1/data-sources/gleif/exceptions/', params=params)
+
+    # ── GCP (Global Carbon Project) Methods ───────────────────────────
+
+    async def get_gcp_national_emissions_async(
+        self,
+        country_code: Optional[str] = None,
+        year: Optional[int] = None,
+        budget_version: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Get GCP national CO2 emissions.
+
+        Returns territorial and consumption-based CO2 emissions by country
+        and year, including per-capita values.
+
+        Args:
+            country_code: ISO-3 country code (e.g. 'USA', 'CHN', 'IND').
+            year: Emission year (e.g. 2020).
+            budget_version: GCP budget version (e.g. '2024').
+            limit: Results per page.
+            offset: Pagination offset.
+
+        Returns:
+            Paginated response with national emissions records.
+        """
+        params = {
+            'country_code': country_code,
+            'year': year,
+            'budget_version': budget_version,
+            'limit': limit,
+            'offset': offset,
+        }
+        return await self._request_async('GET', '/api/v1/data-sources/gcp/national-emissions/', params=params)
+
+    async def get_gcp_emissions_by_fuel_async(
+        self,
+        year: Optional[int] = None,
+        budget_version: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Get GCP global fossil CO2 emissions by fuel type.
+
+        Returns emissions from coal, oil, gas, cement, flaring, and other
+        sources by year.
+
+        Args:
+            year: Emission year (e.g. 2020).
+            budget_version: GCP budget version (e.g. '2024').
+            limit: Results per page.
+            offset: Pagination offset.
+
+        Returns:
+            Paginated response with fuel-type emission records.
+        """
+        params = {
+            'year': year,
+            'budget_version': budget_version,
+            'limit': limit,
+            'offset': offset,
+        }
+        return await self._request_async('GET', '/api/v1/data-sources/gcp/emissions-by-fuel/', params=params)
+
+    async def get_gcp_carbon_budget_async(
+        self,
+        year: Optional[int] = None,
+        budget_version: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Get GCP global carbon budget.
+
+        Returns global carbon budget components (fossil emissions, land-use
+        change, atmospheric growth, ocean sink, land sink) by year.
+
+        Args:
+            year: Budget year (e.g. 2020).
+            budget_version: GCP budget version (e.g. '2024').
+            limit: Results per page.
+            offset: Pagination offset.
+
+        Returns:
+            Paginated response with carbon budget records.
+        """
+        params = {
+            'year': year,
+            'budget_version': budget_version,
+            'limit': limit,
+            'offset': offset,
+        }
+        return await self._request_async('GET', '/api/v1/data-sources/gcp/carbon-budget/', params=params)
+
+    async def get_gcp_methane_budget_async(
+        self,
+        year: Optional[int] = None,
+        budget_version: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Get GCP global methane budget.
+
+        Returns methane budget components (anthropogenic and natural sources
+        and sinks) by year.
+
+        Args:
+            year: Budget year (e.g. 2020).
+            budget_version: GCP budget version (e.g. '2024').
+            limit: Results per page.
+            offset: Pagination offset.
+
+        Returns:
+            Paginated response with methane budget records.
+        """
+        params = {
+            'year': year,
+            'budget_version': budget_version,
+            'limit': limit,
+            'offset': offset,
+        }
+        return await self._request_async('GET', '/api/v1/data-sources/gcp/methane-budget/', params=params)
+
+    # ── NOAA Storm Events Methods ─────────────────────────────────────
+
+    async def get_noaa_storm_events_async(
+        self,
+        event_type: Optional[str] = None,
+        state: Optional[str] = None,
+        year: Optional[int] = None,
+        month: Optional[int] = None,
+        bbox: Optional[str] = None,
+        lat: Optional[float] = None,
+        lon: Optional[float] = None,
+        radius_km: Optional[float] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Get NOAA severe weather events.
+
+        Returns storm event records across the United States including
+        tornadoes, hurricanes, floods, hail, thunderstorms, winter storms,
+        and more.
+
+        Args:
+            event_type: Storm event type (e.g. 'Tornado', 'Hurricane',
+                'Flood', 'Hail', 'Thunderstorm Wind', 'Winter Storm').
+            state: US state name in uppercase (e.g. 'TEXAS', 'FLORIDA').
+            year: Event year (2015-2024 available).
+            month: Event month (1-12).
+            bbox: Bounding box as 'min_lat,min_lon,max_lat,max_lon'.
+            lat: Latitude for point+radius search (-90 to 90).
+            lon: Longitude for point+radius search (-180 to 180).
+            radius_km: Search radius in km (requires lat and lon).
+            limit: Results per page.
+            offset: Pagination offset.
+
+        Returns:
+            Paginated response with storm event records including
+            event type, location, dates, damage, injuries, and deaths.
+        """
+        params = {
+            'event_type': event_type,
+            'state': state,
+            'year': year,
+            'month': month,
+            'bbox': bbox,
+            'lat': lat,
+            'lon': lon,
+            'radius_km': radius_km,
+            'limit': limit,
+            'offset': offset,
+        }
+        return await self._request_async('GET', '/api/v1/data-sources/noaa_storm_events/events/', params=params)

--- a/tests/test_user_client.py
+++ b/tests/test_user_client.py
@@ -856,3 +856,197 @@ class TestGLEIF:
         result = client.get_gleif_entities(search="Apple")
         assert result == OK
         client.close()
+
+
+# ── GCP (Global Carbon Project) ──────────────────────────────────────────────
+
+class TestGCPNationalEmissions:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_basic(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/gcp/national-emissions/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_gcp_national_emissions_async()
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_with_filters(self):
+        route = respx.get(f"{BASE_URL}/api/v1/data-sources/gcp/national-emissions/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_gcp_national_emissions_async(
+            country_code="USA", year=2020, budget_version="2024", limit=100,
+        )
+        assert route.called
+        assert result == OK
+        await client.close_async()
+
+
+class TestGCPEmissionsByFuel:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_basic(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/gcp/emissions-by-fuel/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_gcp_emissions_by_fuel_async()
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_with_filters(self):
+        route = respx.get(f"{BASE_URL}/api/v1/data-sources/gcp/emissions-by-fuel/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_gcp_emissions_by_fuel_async(
+            year=2020, budget_version="2024", limit=50,
+        )
+        assert route.called
+        assert result == OK
+        await client.close_async()
+
+
+class TestGCPCarbonBudget:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_basic(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/gcp/carbon-budget/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_gcp_carbon_budget_async()
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_with_filters(self):
+        route = respx.get(f"{BASE_URL}/api/v1/data-sources/gcp/carbon-budget/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_gcp_carbon_budget_async(
+            year=2020, budget_version="2024", limit=10,
+        )
+        assert route.called
+        assert result == OK
+        await client.close_async()
+
+
+class TestGCPMethaneBudget:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_basic(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/gcp/methane-budget/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_gcp_methane_budget_async()
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_with_filters(self):
+        route = respx.get(f"{BASE_URL}/api/v1/data-sources/gcp/methane-budget/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_gcp_methane_budget_async(
+            year=2020, budget_version="2024", limit=10,
+        )
+        assert route.called
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    def test_gcp_sync_wrapper(self):
+        """Verify sync wrapper works for GCP."""
+        respx.get(f"{BASE_URL}/api/v1/data-sources/gcp/national-emissions/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = client.get_gcp_national_emissions(country_code="USA")
+        assert result == OK
+        client.close()
+
+
+# ── NOAA Storm Events ─────────────────────────────────────────────────────────
+
+class TestNOAAStormEvents:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_basic(self):
+        respx.get(f"{BASE_URL}/api/v1/data-sources/noaa_storm_events/events/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_noaa_storm_events_async()
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_with_standard_filters(self):
+        route = respx.get(f"{BASE_URL}/api/v1/data-sources/noaa_storm_events/events/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_noaa_storm_events_async(
+            event_type="Tornado", state="TEXAS", year=2023, month=1, limit=100,
+        )
+        assert route.called
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_with_spatial_bbox(self):
+        route = respx.get(f"{BASE_URL}/api/v1/data-sources/noaa_storm_events/events/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_noaa_storm_events_async(
+            bbox="25.0,-100.0,36.5,-93.5", year=2023, limit=50,
+        )
+        assert route.called
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_with_spatial_point_radius(self):
+        route = respx.get(f"{BASE_URL}/api/v1/data-sources/noaa_storm_events/events/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = await client.get_noaa_storm_events_async(
+            lat=29.76, lon=-95.37, radius_km=50.0, event_type="Tornado", year=2023,
+        )
+        assert route.called
+        assert result == OK
+        await client.close_async()
+
+    @respx.mock
+    def test_noaa_sync_wrapper(self):
+        """Verify sync wrapper works for NOAA."""
+        respx.get(f"{BASE_URL}/api/v1/data-sources/noaa_storm_events/events/").mock(
+            return_value=httpx.Response(200, json=OK)
+        )
+        client = _client()
+        result = client.get_noaa_storm_events(state="TEXAS", year=2023)
+        assert result == OK
+        client.close()


### PR DESCRIPTION
## Summary
- Add 5 new async methods to EkoUserClient for GCP (Global Carbon Project) and NOAA Storm Events
- GCP methods: national emissions, emissions by fuel, carbon budget, methane budget
- NOAA method: storm events with standard filters + spatial queries (bbox, point+radius)
- 13 new tests (323 total suite), all passing
- Updated README with GLEIF, GCP, and NOAA method documentation

## Test plan
- [x] All 323 tests pass (76 user_client tests)
- [x] Sync wrapper auto-generation verified for both GCP and NOAA
- [x] API endpoints verified against live dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)