### PR TITLE
fix(tests/integration): use login_password() for JWT auth in live_client fixture

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -38,7 +38,15 @@ def live_client(live_credentials):
     """JWT-authenticated EkoUserClient pointed at api-test.jana.earth.
 
     Uses the JWT auth path (auth-dev for ``/api/auth/*``, api-test for
-    everything else). The client logs in once per test session.
+    everything else). The client logs in once per test session via
+    :meth:`JwtAuthMixin.login_password`, which posts ``{email, password}``
+    to ``/api/auth/login/`` and stores ``access_token`` / ``refresh_token``.
+
+    Note: we deliberately do NOT pass ``username``/``password`` to the
+    constructor. The base ``BaseEkoClient.__init__`` auto-login path uses
+    the legacy DRF token endpoint (``{username, password}`` payload), which
+    the JWT auth server rejects with HTTP 400. We must explicitly call
+    ``login_password`` after construction to use the JWT flow.
     """
     from eko_client.user_client import EkoUserClient
 
@@ -46,10 +54,7 @@ def live_client(live_credentials):
     client = EkoUserClient(
         base_url=AUTH_BASE_URL,
         api_base_url=API_BASE_URL,
-        # JWT login uses email/password kwargs on EkoUserClient. The
-        # constructor handles the login and stores the access token.
-        username=email,
-        password=password,
     )
+    client.login_password(email=email, password=password)
     yield client
     client.close()


### PR DESCRIPTION
## Summary

Hotfix for the nightly-contract workflow auth failure (run [25144385761](https://github.com/Jana-Earth-Data/jana-eko-client/actions/runs/25144385761)).

The `live_client` fixture in `tests/integration/conftest.py` passed `username=email`/`password=password` to `EkoUserClient(...)`, expecting the constructor's auto-login path to use the JWT flow. But `BaseEkoClient.__init__` wires that into `self.login()`, which posts `{username, password}` to `/api/auth/login/` — the legacy DRF token-auth shape. `auth-dev.jana.earth`'s JWT login expects `{email, password}` and rejects the legacy payload with HTTP 400.

All 4 climatetrace integration tests ERRORed at fixture setup with:
```
eko_client.exceptions.EkoAPIError: API error: 400
```

## Fix

- Construct `EkoUserClient` *without* `username`/`password` (skipping the auto-login branch)
- Explicitly call `client.login_password(email=, password=)` — `JwtAuthMixin`'s correct JWT entrypoint, which posts `{email, password}` and stores `access_token` / `refresh_token`

The legacy DRF login path on `BaseEkoClient` is untouched for any consumers still using token auth.

## Test plan

- [ ] Merge to `development`, then promote `development → main` (workflow only registers from default branch)
- [ ] Re-dispatch `nightly-contract.yml` against `main`
- [ ] All 4 `TestClimateTraceLive` tests pass against `api-test.jana.earth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)