### PR TITLE
Jana #172 v0.3.0 prep: canonical-only kwargs across data-source methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Client for accessing all unified environmental data APIs.
 - `get_climatetrace_emissions()` - Get Climate TRACE emissions
 - `get_climatetrace_sector_assets(id)` - Assets within a sector
 - `get_climatetrace_sector_emissions_summary(id)` - Sector emission summary
-- `get_climatetrace_country_assets(country_code)` - Assets within a country
+- `get_climatetrace_country_assets(country_id)` - Assets within a country
 - `get_climatetrace_asset_emissions(id)` - Emissions for an asset
 - `get_climatetrace_asset_violations(id)` - Violations for an asset
 - `get_climatetrace_aggregated_emissions()` - Aggregated emission records

--- a/eko_client/user_client.py
+++ b/eko_client/user_client.py
@@ -584,31 +584,37 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
         self,
         location_id: Optional[int] = None,
         parameter: Optional[str] = None,
-        country_code: Optional[str] = None,
+        country_iso2: Optional[str] = None,
         location_bbox: Optional[List[float]] = None,
         coordinates: Optional[List[float]] = None,
         radius_km: Optional[float] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        # --- Deprecated aliases (Jana #172) -----------------------------
+        country_code: Optional[str] = None,  # deprecated alias for country_iso2
     ) -> Dict[str, Any]:
         """Get OpenAQ sensors.
 
         Args:
             location_id: Filter by location FK ID.
             parameter: Filter by parameter name.
-            country_code: Filter by country ISO3 code.
+            country_iso2: Filter by ISO 3166-1 ALPHA-2 country code on the related
+                Location (e.g. 'US', 'NP'). OpenAQ uses alpha-2, NOT alpha-3.
             location_bbox: Bounding box [min_lon, min_lat, max_lon, max_lat].
             coordinates: Point [lon, lat] (requires radius_km).
             radius_km: Radius in km around *coordinates*.
             limit: Max results to return.
             offset: Pagination offset.
+            country_code: **Deprecated** — use ``country_iso2`` instead. Earlier
+                docs incorrectly described this as an ISO3 code; OpenAQ is alpha-2.
         """
         bbox_str = ','.join(str(v) for v in location_bbox) if location_bbox else None
         coords_str = ','.join(str(v) for v in coordinates) if coordinates else None
+        country = country_iso2 if country_iso2 is not None else country_code
         params = {
             'location_id': location_id,
             'parameter__name': parameter,
-            'location__country_code': country_code,
+            'location__country_iso2': country,
             'bbox': bbox_str,
             'coordinates': coords_str,
             'radius': radius_km,
@@ -628,12 +634,14 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
         parameter: Optional[str] = None,
         date_from: Optional[Union[str, datetime]] = None,
         date_to: Optional[Union[str, datetime]] = None,
-        country_code: Optional[str] = None,
+        country_iso2: Optional[str] = None,
         ordering: Optional[str] = None,
         page: Optional[int] = None,
         page_size: Optional[int] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        # --- Deprecated aliases (Jana #172) -----------------------------
+        country_code: Optional[str] = None,  # deprecated alias for country_iso2
     ) -> Dict[str, Any]:
         """Get OpenAQ measurements.
 
@@ -642,19 +650,22 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
             parameter: Filter by parameter name (e.g. 'pm25', 'o3').
             date_from: Start date (ISO 8601 string or datetime).
             date_to: End date (ISO 8601 string or datetime).
-            country_code: Filter by country code (e.g. 'US').
+            country_iso2: Filter by ISO 3166-1 ALPHA-2 country code (e.g. 'US', 'NP').
+                OpenAQ uses alpha-2, NOT alpha-3.
             ordering: Sort field (e.g. 'measured_at', '-measured_at').
             page: Page number (1-based, used with page_size).
             page_size: Number of results per page.
             limit: Alias for page_size (backward compatibility).
             offset: Result offset (backward compatibility).
+            country_code: **Deprecated** — use ``country_iso2`` instead (Jana #172).
         """
+        country = country_iso2 if country_iso2 is not None else country_code
         params = {
             'location_id': location_id,
             'parameter_name': parameter,
             'date_from': date_from.isoformat() if isinstance(date_from, datetime) else date_from,
             'date_to': date_to.isoformat() if isinstance(date_to, datetime) else date_to,
-            'location__country_code': country_code,
+            'location__country_iso2': country,
             'ordering': ordering,
             'page': page,
             'page_size': page_size or limit,
@@ -1006,17 +1017,32 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
     # EDGAR Methods
     async def get_edgar_country_totals_async(
         self,
-        country_code: Optional[str] = None,
+        country_iso3: Optional[str] = None,
         year: Optional[int] = None,
         gas: Optional[str] = None,
         sector: Optional[str] = None,
         provisional: Optional[bool] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        # --- Deprecated aliases (Jana #172) -----------------------------
+        country_code: Optional[str] = None,  # deprecated alias for country_iso3
     ) -> Dict[str, Any]:
-        """Get EDGAR country totals."""
+        """Get EDGAR country totals.
+
+        Args:
+            country_iso3: ISO 3166-1 alpha-3 country code (e.g. 'USA', 'NPL').
+            year: Calendar year.
+            gas: Gas type (e.g. 'co2', 'ch4', 'n2o'). Server alias for ``gas_type``.
+            sector: EDGAR sector slug.
+            provisional: Whether the record is provisional.
+            limit: Results per page.
+            offset: Pagination offset.
+            country_code: **Deprecated** — use ``country_iso3`` instead. Kept for
+                backward compatibility with v0.x callers (Jana #172 platform-canonical
+                naming). Server still accepts it as an alias.
+        """
         params = {
-            'country_code': country_code,
+            'country_iso3': country_iso3 if country_iso3 is not None else country_code,
             'year': year,
             'gas': gas,
             'sector': sector,
@@ -1086,17 +1112,24 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
 
     async def get_edgar_fasttrack_async(
         self,
-        country_code: Optional[str] = None,
+        country_iso3: Optional[str] = None,
         year: Optional[int] = None,
         gas: Optional[str] = None,
         sector: Optional[str] = None,
         provisional: Optional[bool] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        # --- Deprecated aliases (Jana #172) -----------------------------
+        country_code: Optional[str] = None,  # deprecated alias for country_iso3
     ) -> Dict[str, Any]:
-        """Get EDGAR fasttrack data."""
+        """Get EDGAR fasttrack data.
+
+        Args:
+            country_iso3: ISO 3166-1 alpha-3 country code (e.g. 'USA').
+            country_code: **Deprecated** — use ``country_iso3`` instead (Jana #172).
+        """
         params = {
-            'country_code': country_code,
+            'country_iso3': country_iso3 if country_iso3 is not None else country_code,
             'year': year,
             'gas': gas,
             'sector': sector,
@@ -1253,11 +1286,13 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
 
     async def get_gcp_national_emissions_async(
         self,
-        country_code: Optional[str] = None,
+        country_iso3: Optional[str] = None,
         year: Optional[int] = None,
         budget_version: Optional[str] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        # --- Deprecated aliases (Jana #172) -----------------------------
+        country_code: Optional[str] = None,  # deprecated alias for country_iso3
     ) -> Dict[str, Any]:
         """Get GCP national CO2 emissions.
 
@@ -1265,17 +1300,18 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
         and year, including per-capita values.
 
         Args:
-            country_code: ISO-3 country code (e.g. 'USA', 'CHN', 'IND').
+            country_iso3: ISO 3166-1 alpha-3 country code (e.g. 'USA', 'CHN', 'IND').
             year: Emission year (e.g. 2020).
             budget_version: GCP budget version (e.g. '2024').
             limit: Results per page.
             offset: Pagination offset.
+            country_code: **Deprecated** — use ``country_iso3`` instead (Jana #172).
 
         Returns:
             Paginated response with national emissions records.
         """
         params = {
-            'country_code': country_code,
+            'country_iso3': country_iso3 if country_iso3 is not None else country_code,
             'year': year,
             'budget_version': budget_version,
             'limit': limit,
@@ -1852,30 +1888,33 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
 
     async def get_edgar_air_pollutant_totals_async(
         self,
-        country_code: Optional[str] = None,
+        country_iso3: Optional[str] = None,
         year: Optional[int] = None,
         gas: Optional[str] = None,
         sector: Optional[str] = None,
         ordering: Optional[str] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        # --- Deprecated aliases (Jana #172) -----------------------------
+        country_code: Optional[str] = None,  # deprecated alias for country_iso3
     ) -> Dict[str, Any]:
         """Get EDGAR air pollutant country totals.
 
         Args:
-            country_code: ISO-3 country code (e.g. 'USA').
+            country_iso3: ISO 3166-1 alpha-3 country code (e.g. 'USA').
             year: Emission year.
             gas: Pollutant type (e.g. 'NOx', 'SO2', 'CO', 'PM2.5').
             sector: EDGAR sector code.
             ordering: Sort field (country_code, year, gas, sector, value, ingested_at).
             limit: Results per page.
             offset: Pagination offset.
+            country_code: **Deprecated** — use ``country_iso3`` instead (Jana #172).
 
         Returns:
             Paginated response (cursor-based) with air pollutant total records.
         """
         params = {
-            'country_code': country_code,
+            'country_iso3': country_iso3 if country_iso3 is not None else country_code,
             'year': year,
             'gas': gas,
             'sector': sector,

--- a/eko_client/user_client.py
+++ b/eko_client/user_client.py
@@ -590,8 +590,6 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
         radius_km: Optional[float] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-        # --- Deprecated aliases (Jana #172) -----------------------------
-        country_code: Optional[str] = None,  # deprecated alias for country_iso2
     ) -> Dict[str, Any]:
         """Get OpenAQ sensors.
 
@@ -600,21 +598,20 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
             parameter: Filter by parameter name.
             country_iso2: Filter by ISO 3166-1 ALPHA-2 country code on the related
                 Location (e.g. 'US', 'NP'). OpenAQ uses alpha-2, NOT alpha-3.
+                Canonical-only (Jana #172): the legacy ``country_code`` kwarg
+                has been removed.
             location_bbox: Bounding box [min_lon, min_lat, max_lon, max_lat].
             coordinates: Point [lon, lat] (requires radius_km).
             radius_km: Radius in km around *coordinates*.
             limit: Max results to return.
             offset: Pagination offset.
-            country_code: **Deprecated** — use ``country_iso2`` instead. Earlier
-                docs incorrectly described this as an ISO3 code; OpenAQ is alpha-2.
         """
         bbox_str = ','.join(str(v) for v in location_bbox) if location_bbox else None
         coords_str = ','.join(str(v) for v in coordinates) if coordinates else None
-        country = country_iso2 if country_iso2 is not None else country_code
         params = {
             'location_id': location_id,
             'parameter__name': parameter,
-            'location__country_iso2': country,
+            'location__country_iso2': country_iso2,
             'bbox': bbox_str,
             'coordinates': coords_str,
             'radius': radius_km,
@@ -640,8 +637,6 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
         page_size: Optional[int] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-        # --- Deprecated aliases (Jana #172) -----------------------------
-        country_code: Optional[str] = None,  # deprecated alias for country_iso2
     ) -> Dict[str, Any]:
         """Get OpenAQ measurements.
 
@@ -651,21 +646,20 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
             date_from: Start date (ISO 8601 string or datetime).
             date_to: End date (ISO 8601 string or datetime).
             country_iso2: Filter by ISO 3166-1 ALPHA-2 country code (e.g. 'US', 'NP').
-                OpenAQ uses alpha-2, NOT alpha-3.
+                OpenAQ uses alpha-2, NOT alpha-3. Canonical-only (Jana #172):
+                the legacy ``country_code`` kwarg has been removed.
             ordering: Sort field (e.g. 'measured_at', '-measured_at').
             page: Page number (1-based, used with page_size).
             page_size: Number of results per page.
             limit: Alias for page_size (backward compatibility).
             offset: Result offset (backward compatibility).
-            country_code: **Deprecated** — use ``country_iso2`` instead (Jana #172).
         """
-        country = country_iso2 if country_iso2 is not None else country_code
         params = {
             'location_id': location_id,
             'parameter_name': parameter,
             'date_from': date_from.isoformat() if isinstance(date_from, datetime) else date_from,
             'date_to': date_to.isoformat() if isinstance(date_to, datetime) else date_to,
-            'location__country_iso2': country,
+            'location__country_iso2': country_iso2,
             'ordering': ordering,
             'page': page,
             'page_size': page_size or limit,
@@ -1024,25 +1018,23 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
         provisional: Optional[bool] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-        # --- Deprecated aliases (Jana #172) -----------------------------
-        country_code: Optional[str] = None,  # deprecated alias for country_iso3
     ) -> Dict[str, Any]:
         """Get EDGAR country totals.
 
         Args:
             country_iso3: ISO 3166-1 alpha-3 country code (e.g. 'USA', 'NPL').
+                Canonical-only (Jana #172): the legacy ``country_code`` kwarg
+                has been removed.
             year: Calendar year.
-            gas: Gas type (e.g. 'co2', 'ch4', 'n2o'). Server alias for ``gas_type``.
+            gas: Gas type (e.g. 'co2', 'ch4', 'n2o'). Canonical name; the
+                legacy server param ``gas_type`` is no longer accepted.
             sector: EDGAR sector slug.
             provisional: Whether the record is provisional.
             limit: Results per page.
             offset: Pagination offset.
-            country_code: **Deprecated** — use ``country_iso3`` instead. Kept for
-                backward compatibility with v0.x callers (Jana #172 platform-canonical
-                naming). Server still accepts it as an alias.
         """
         params = {
-            'country_iso3': country_iso3 if country_iso3 is not None else country_code,
+            'country_iso3': country_iso3,
             'year': year,
             'gas': gas,
             'sector': sector,
@@ -1119,17 +1111,16 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
         provisional: Optional[bool] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-        # --- Deprecated aliases (Jana #172) -----------------------------
-        country_code: Optional[str] = None,  # deprecated alias for country_iso3
     ) -> Dict[str, Any]:
         """Get EDGAR fasttrack data.
 
         Args:
             country_iso3: ISO 3166-1 alpha-3 country code (e.g. 'USA').
-            country_code: **Deprecated** — use ``country_iso3`` instead (Jana #172).
+                Canonical-only (Jana #172): the legacy ``country_code`` kwarg
+                has been removed.
         """
         params = {
-            'country_iso3': country_iso3 if country_iso3 is not None else country_code,
+            'country_iso3': country_iso3,
             'year': year,
             'gas': gas,
             'sector': sector,
@@ -1291,8 +1282,6 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
         budget_version: Optional[str] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-        # --- Deprecated aliases (Jana #172) -----------------------------
-        country_code: Optional[str] = None,  # deprecated alias for country_iso3
     ) -> Dict[str, Any]:
         """Get GCP national CO2 emissions.
 
@@ -1301,17 +1290,18 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
 
         Args:
             country_iso3: ISO 3166-1 alpha-3 country code (e.g. 'USA', 'CHN', 'IND').
+                Canonical-only (Jana #172): the legacy ``country_code`` kwarg
+                has been removed.
             year: Emission year (e.g. 2020).
             budget_version: GCP budget version (e.g. '2024').
             limit: Results per page.
             offset: Pagination offset.
-            country_code: **Deprecated** — use ``country_iso3`` instead (Jana #172).
 
         Returns:
             Paginated response with national emissions records.
         """
         params = {
-            'country_iso3': country_iso3 if country_iso3 is not None else country_code,
+            'country_iso3': country_iso3,
             'year': year,
             'budget_version': budget_version,
             'limit': limit,
@@ -1790,7 +1780,7 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
         country_iso3: Optional[str] = None,
         year: Optional[int] = None,
         sector: Optional[str] = None,
-        gas_type: Optional[str] = None,
+        gas: Optional[str] = None,
         search: Optional[str] = None,
         ordering: Optional[str] = None,
         limit: Optional[int] = None,
@@ -1801,8 +1791,10 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
         Args:
             country_iso3: ISO-3 country code (e.g. 'USA').
             year: Emission year.
-            sector: Sector name filter.
-            gas_type: Gas type filter.
+            sector: Sector name filter (this endpoint accepts ``sector``,
+                not ``sector_name``).
+            gas: Gas filter (e.g. 'co2', 'ch4', 'n2o'). Canonical-only
+                (Jana #172): the legacy ``gas_type`` kwarg has been removed.
             search: Search country_name or country_iso3.
             ordering: Sort field (year, emissions_quantity, country_iso3).
             limit: Results per page.
@@ -1815,7 +1807,7 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
             'country_iso3': country_iso3,
             'year': year,
             'sector': sector,
-            'gas_type': gas_type,
+            'gas': gas,
             'search': search,
             'ordering': ordering,
             'limit': limit,
@@ -1895,26 +1887,25 @@ class EkoUserClient(JwtAuthMixin, BaseEkoClient):
         ordering: Optional[str] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-        # --- Deprecated aliases (Jana #172) -----------------------------
-        country_code: Optional[str] = None,  # deprecated alias for country_iso3
     ) -> Dict[str, Any]:
         """Get EDGAR air pollutant country totals.
 
         Args:
             country_iso3: ISO 3166-1 alpha-3 country code (e.g. 'USA').
+                Canonical-only (Jana #172): the legacy ``country_code`` kwarg
+                has been removed.
             year: Emission year.
             gas: Pollutant type (e.g. 'NOx', 'SO2', 'CO', 'PM2.5').
             sector: EDGAR sector code.
-            ordering: Sort field (country_code, year, gas, sector, value, ingested_at).
+            ordering: Sort field (country_iso3, year, gas, sector, value, ingested_at).
             limit: Results per page.
             offset: Pagination offset.
-            country_code: **Deprecated** — use ``country_iso3`` instead (Jana #172).
 
         Returns:
             Paginated response (cursor-based) with air pollutant total records.
         """
         params = {
-            'country_iso3': country_iso3 if country_iso3 is not None else country_code,
+            'country_iso3': country_iso3,
             'year': year,
             'gas': gas,
             'sector': sector,

--- a/jana_eko_client_test_suite.ipynb
+++ b/jana_eko_client_test_suite.ipynb
@@ -423,46 +423,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "================================================================================\n",
-      "  Climate TRACE - Assets & Emissions\n",
-      "================================================================================\n",
-      "  [✓ PASS] Climate TRACE Assets                                  877.5ms (5 records)\n",
-      "  [✓ PASS] Climate TRACE Emissions                               381.5ms (5 records)\n",
-      "  [✓ PASS] Climate TRACE Assets (USA)                            337.3ms (0 records)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "TestResult(test_name='Climate TRACE Assets (USA)', method_called=\"get_climatetrace_assets(country_code='US', limit=5)\", response_time_ms=337.3, passed=True, error=None, record_count=0)"
-      ]
-     },
-     "execution_count": 42,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "section(\"Climate TRACE - Assets & Emissions\")\n",
-    "\n",
-    "test_method(\"Climate TRACE Assets\", \"get_climatetrace_assets(limit=5)\", \n",
-    "            client.get_climatetrace_assets, limit=5)\n",
-    "\n",
-    "test_method(\"Climate TRACE Emissions\", \"get_climatetrace_emissions(limit=5)\", \n",
-    "            client.get_climatetrace_emissions, limit=5)\n",
-    "\n",
-    "# Use asset filtering instead of direct country filtering\n",
-    "test_method(\"Climate TRACE Assets (USA)\", \"get_climatetrace_assets(country_code='US', limit=5)\", \n",
-    "            client.get_climatetrace_assets, country_code=\"US\", limit=5)"
-   ]
+   "outputs": [],
+   "source": "section(\"Climate TRACE - Assets & Emissions\")\n\ntest_method(\"Climate TRACE Assets\", \"get_climatetrace_assets(limit=5)\", \n            client.get_climatetrace_assets, limit=5)\n\ntest_method(\"Climate TRACE Emissions\", \"get_climatetrace_emissions(limit=5)\", \n            client.get_climatetrace_emissions, limit=5)\n\n# Jana #172 canonical-only: 'country_iso3' is the only accepted kwarg.\ntest_method(\"Climate TRACE Assets (USA)\", \"get_climatetrace_assets(country_iso3='USA', limit=5)\", \n            client.get_climatetrace_assets, country_iso3=\"USA\", limit=5)"
   },
   {
    "cell_type": "code",
@@ -516,106 +480,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "================================================================================\n",
-      "  EDGAR - Country Totals & Temporal Profiles\n",
-      "================================================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Error response is not valid JSON: Expecting value: line 1 column 1 (char 0). Status: 503\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [✗ FAIL] EDGAR Country Totals                                  304.6ms\n",
-      "         Error: <html>\n",
-      "<head><title>503 Service Temporarily Unavailable</title></head>\n",
-      "<body>\n",
-      "<center><h1>503 Service Temporarily Unavailable</h1></center>\n",
-      "</body>\n",
-      "</html>\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Error response is not valid JSON: Expecting value: line 1 column 1 (char 0). Status: 503\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [✗ FAIL] EDGAR Country Totals (USA)                            359.8ms\n",
-      "         Error: <html>\n",
-      "<head><title>503 Service Temporarily Unavailable</title></head>\n",
-      "<body>\n",
-      "<center><h1>503 Service Temporarily Unavailable</h1></center>\n",
-      "</body>\n",
-      "</html>\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Error response is not valid JSON: Expecting value: line 1 column 1 (char 0). Status: 503\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [✗ FAIL] EDGAR Temporal Profiles                               343.3ms\n",
-      "         Error: <html>\n",
-      "<head><title>503 Service Temporarily Unavailable</title></head>\n",
-      "<body>\n",
-      "<center><h1>503 Service Temporarily Unavailable</h1></center>\n",
-      "</body>\n",
-      "</html>\n",
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "TestResult(test_name='EDGAR Temporal Profiles', method_called='get_edgar_temporal_profiles(limit=5)', response_time_ms=343.3, passed=False, error='<html>\\r\\n<head><title>503 Service Temporarily Unavailable</title></head>\\r\\n<body>\\r\\n<center><h1>503 Service Temporarily Unavailable</h1></center>\\r\\n</body>\\r\\n</html>\\r\\n', record_count=None)"
-      ]
-     },
-     "execution_count": 44,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "section(\"EDGAR - Country Totals & Temporal Profiles\")\n",
-    "\n",
-    "test_method(\"EDGAR Country Totals\", \"get_edgar_country_totals(limit=5)\", \n",
-    "            client.get_edgar_country_totals, limit=5)\n",
-    "\n",
-    "# Fix: parameter is country_code not country\n",
-    "test_method(\"EDGAR Country Totals (USA)\", \"get_edgar_country_totals(country_code='USA', limit=5)\", \n",
-    "            client.get_edgar_country_totals, country_code=\"USA\", limit=5)\n",
-    "\n",
-    "test_method(\"EDGAR Temporal Profiles\", \"get_edgar_temporal_profiles(limit=5)\", \n",
-    "            client.get_edgar_temporal_profiles, limit=5)"
-   ]
+   "outputs": [],
+   "source": "section(\"EDGAR - Country Totals & Temporal Profiles\")\n\ntest_method(\"EDGAR Country Totals\", \"get_edgar_country_totals(limit=5)\", \n            client.get_edgar_country_totals, limit=5)\n\n# Jana #172 canonical-only: 'country_iso3' is the only accepted kwarg.\ntest_method(\"EDGAR Country Totals (USA)\", \"get_edgar_country_totals(country_iso3='USA', limit=5)\", \n            client.get_edgar_country_totals, country_iso3=\"USA\", limit=5)\n\ntest_method(\"EDGAR Temporal Profiles\", \"get_edgar_temporal_profiles(limit=5)\", \n            client.get_edgar_temporal_profiles, limit=5)"
   },
   {
    "cell_type": "code",

--- a/test_client.py
+++ b/test_client.py
@@ -302,8 +302,9 @@ def test_source_specific_endpoints(client):
         # Test with filters
         print(f"   3a. Testing get_climatetrace_assets with country filter...")
         try:
+            # Jana #172 canonical-only: 'country_iso3' is the only accepted kwarg.
             filtered_assets = client.get_climatetrace_assets(
-                country_code="USA",
+                country_iso3="USA",
                 limit=5
             )
             filtered_count = len(filtered_assets.get('results', []))
@@ -388,8 +389,9 @@ def test_source_specific_endpoints(client):
         # Test with filters
         print(f"   1a. Testing get_edgar_country_totals with filters...")
         try:
+            # Jana #172 canonical-only: 'country_iso3' is the only accepted kwarg.
             filtered_totals = client.get_edgar_country_totals(
-                country_code="USA",
+                country_iso3="USA",
                 year=2023,
                 gas="CO2",
                 limit=5

--- a/tests/test_user_client.py
+++ b/tests/test_user_client.py
@@ -370,10 +370,11 @@ class TestOpenAQ:
             return_value=httpx.Response(200, json=OK)
         )
         client = _client()
+        # Jana #172 canonical-only: 'country_iso2' is the only accepted kwarg.
         result = await client.get_openaq_sensors_async(
             location_id=1,
             parameter="pm25",
-            country_code="US",
+            country_iso2="US",
             location_bbox=[80, 26, 88, 30],
             coordinates=[85.3, 27.7],
             radius_km=10.0,
@@ -684,8 +685,9 @@ class TestEDGAR:
             return_value=httpx.Response(200, json=OK)
         )
         client = _client()
+        # Jana #172 canonical-only: 'country_iso3' is the only accepted kwarg.
         result = await client.get_edgar_country_totals_async(
-            country_code="USA", year=2023, gas="CO2",
+            country_iso3="USA", year=2023, gas="CO2",
         )
         assert result == OK
         await client.close_async()
@@ -737,7 +739,8 @@ class TestEDGAR:
             return_value=httpx.Response(200, json=OK)
         )
         client = _client()
-        result = client.get_edgar_country_totals(country_code="NPL")
+        # Jana #172 canonical-only: 'country_iso3' is the only accepted kwarg.
+        result = client.get_edgar_country_totals(country_iso3="NPL")
         assert result == OK
         client.close()
 
@@ -850,8 +853,9 @@ class TestGCPNationalEmissions:
             return_value=httpx.Response(200, json=OK)
         )
         client = _client()
+        # Jana #172 canonical-only: 'country_iso3' is the only accepted kwarg.
         result = await client.get_gcp_national_emissions_async(
-            country_code="USA", year=2020, budget_version="2024", limit=100,
+            country_iso3="USA", year=2020, budget_version="2024", limit=100,
         )
         assert route.called
         assert result == OK
@@ -948,7 +952,8 @@ class TestGCPMethaneBudget:
             return_value=httpx.Response(200, json=OK)
         )
         client = _client()
-        result = client.get_gcp_national_emissions(country_code="USA")
+        # Jana #172 canonical-only: 'country_iso3' is the only accepted kwarg.
+        result = client.get_gcp_national_emissions(country_iso3="USA")
         assert result == OK
         client.close()
 
@@ -1332,9 +1337,11 @@ class TestClimateTRACEAnnualCountryEmissions:
             return_value=httpx.Response(200, json=OK)
         )
         client = _client()
+        # Jana #172 canonical-only: 'gas' is the only accepted kwarg
+        # (legacy 'gas_type' removed).
         result = await client.get_climatetrace_annual_country_emissions_async(
             country_iso3="USA", year=2020, sector="power",
-            gas_type="co2", ordering="-emissions_quantity", limit=50,
+            gas="co2", ordering="-emissions_quantity", limit=50,
         )
         assert route.called
         assert result == OK
@@ -1445,8 +1452,9 @@ class TestEDGARAirPollutant:
             return_value=httpx.Response(200, json=OK)
         )
         client = _client()
+        # Jana #172 canonical-only: 'country_iso3' is the only accepted kwarg.
         result = await client.get_edgar_air_pollutant_totals_async(
-            country_code="USA", year=2022, gas="NOx", limit=10,
+            country_iso3="USA", year=2022, gas="NOx", limit=10,
         )
         assert result == OK
         await client.close_async()


### PR DESCRIPTION
## Summary

Aligns the Python client with the server-side canonical-only filter contract enforced in Jana #172 (server PRs #173/#174, deployed image sha256:31bdf0a6).

- Switches data-source method kwargs to canonical names (`country_iso3`, `country_iso2`)
- Breaking change to method signatures — bumps toward v0.3.0

## Commits
- 4be4103 feat: prefer canonical country_iso3/country_iso2 kwargs (Jana #172)
- 2a5d62c feat!: canonical-only kwargs across data-source methods (Jana #172)

## Test plan
- [ ] Unit tests pass against canonical kwargs
- [ ] Integration smoke test against api-test.jana.earth

🤖 Generated with [Claude Code](https://claude.com/claude-code)